### PR TITLE
chore: restructure project config — slim CLAUDE.md, add skills, agents, hooks

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,23 @@
+---
+name: security-reviewer
+description: Reviews MCP proxy code for injection vulnerabilities and MCP security issues
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+You are a senior security engineer specializing in MCP protocol security and LLM agent injection prevention.
+
+Review code for:
+- Prompt injection via tool responses (role override phrases, "ignore previous instructions", "system:" prefixes)
+- Path traversal in filesystem tool calls (../, encoded variants, symlink following, null bytes)
+- Zero-width unicode character smuggling (U+200B, U+200C, U+200D, U+FEFF, U+2060)
+- Base64-encoded instruction payloads hidden in tool responses
+- Markdown/HTML injection that could alter agent behavior
+- Attempts to override system prompts or tool definitions in MCP responses
+
+Reference vulnerabilities:
+- CVE-2025-6514: mcp-remote CVSS 9.6, arbitrary OS command execution via crafted authorization_endpoint URLs
+- CVE-2025-53110: Filesystem MCP Server directory containment bypass
+- CVE-2025-53109: Filesystem MCP Server symlink traversal bypass
+
+For every finding, provide: specific file and line reference, severity (critical/high/medium/low), the attack vector, and a concrete fix. Do not report speculative issues — only flag patterns that match known attack vectors.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,33 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'src/security/|src/mcp-proxy/sanitizer'; then npx vitest run tests/sanitizer.test.ts tests/injection-patterns.test.ts tests/path-guard.test.ts --reporter=verbose 2>&1; fi",
+            "timeout": 30000
+          },
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_FILE_PATH\" | grep -qE '\\.ts$'; then npx tsc --noEmit 2>&1 | head -20; fi",
+            "timeout": 15000
+          }
+        ]
+      }
+    ],
+    "PreCommit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx vitest run --reporter=verbose 2>&1",
+            "timeout": 60000,
+            "blocking": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/dashboard-integration/SKILL.md
+++ b/.claude/skills/dashboard-integration/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: dashboard-integration
+description: Mission Control integration patterns and time-box rules
+---
+
+## Mission Control (builderz-labs/mission-control)
+
+**WARNING: Alpha software** — APIs, database schemas, and config formats may change between releases. Pin to a specific release tag. Keep the adapter thin so breaking changes upstream don't cascade.
+
+### What It Provides
+- Kanban board (inbox → assigned → in progress → review → done) with drag-and-drop
+- Real-time session tracking for Claude Code (auto-discovers from ~/.claude/projects/)
+- Token usage dashboard with per-model breakdowns, trend charts, cost analysis
+- Memory browser with filesystem-backed memory tree
+- Skill management with built-in security scanner
+- SQLite-based, zero external dependencies, single `pnpm start`
+
+### Integration Surface
+- **Adapter layer** for multi-agent frameworks (OpenClaw, CrewAI, LangGraph, AutoGen, Claude SDK, generic fallback)
+- **Direct CLI mode** — no gateway required for existing CLI agent workflows
+- **Task Bridge** — read-only scanner surfacing tasks from `~/.claude/tasks/`
+- **Webhooks** with HMAC-SHA256 signatures
+- **Comms API** for agent inter-agent messaging
+
+### Our Integration Approach
+1. Register as generic fallback adapter or use Direct CLI path
+2. **Session registration**: When agent-sandbox starts a sandbox, register with Mission Control API
+3. **Task tracking**: Feed agent task into Kanban (inbox → assigned → in progress → review)
+4. **Event streaming**: Forward MCP proxy events (tool calls, injection flags) via webhook/comms API
+5. **Cost data**: Bridge Langfuse token usage to Mission Control cost tracking
+
+### Time-Box Rule
+Spend no more than **2-3 hours** on Mission Control integration. If the API surface doesn't match expectations, switch to agents-observe without guilt.
+
+### Adapter Module Structure
+- `src/dashboard/adapter.ts` — Mission Control API client (session CRUD, task updates)
+- `src/dashboard/event-bridge.ts` — Transforms MCP proxy events into Mission Control format
+- `src/dashboard/config.ts` — URL, API key, enable/disable flag. Opt-in: no-op when not configured.
+
+## Fallback: agents-observe (simple10/agents-observe)
+
+- Real-time tool call visualization, subagent relationship trees
+- Uses Claude Code hooks for event capture (hook script → API server → React dashboard)
+- Docker-based, lighter weight than Mission Control
+- Better for "watch the agent work" visualization, weaker on task management
+- Dashboard at `http://localhost:4981`

--- a/.claude/skills/mcp-proxy/SKILL.md
+++ b/.claude/skills/mcp-proxy/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: mcp-proxy
+description: MCP proxy architecture, JSON-RPC bridging, and allowlist design
+---
+
+## Proxy Role
+
+HTTP server running on the HOST machine, accepting JSON-RPC 2.0 MCP protocol requests from sandboxed agents over HTTP. Sandboxed agents connect via `host.docker.internal:18923` (configurable via `MCP_PROXY_PORT` env var).
+
+## Request Pipeline
+
+For each incoming MCP request:
+1. **Allowlist check** — reject if tool name not in configured allowlist (return structured JSON-RPC error, not silence)
+2. **Path guard** — reject if any file path arguments escape workspace root (traversal, encoded, symlinks)
+3. **Forward** — send to appropriate local MCP server via stdio subprocess
+4. **Sanitize response** — run response content through injection pattern detection, flag/strip/block
+5. **Audit log** — log full call (timestamp, tool name, sanitized args, result status, any flags)
+6. **Return** — send filtered response to caller
+
+## Stdio Bridge
+
+The proxy spawns local MCP servers as stdio subprocesses and bridges them to HTTP. Architecture decision: use `@modelcontextprotocol/sdk` (official TypeScript SDK) with Express.
+
+- `supergateway` and `mcp-proxy` (Python) are CLI-only transport adapters with zero filtering capability — rejected
+- The official SDK provides `McpServer` + `NodeStreamableHTTPServerTransport` + Express middleware
+- Full programmatic control over request/response pipeline for injection filtering
+
+## Allowlist Design
+
+- Configurable per-sandbox via `ALLOWED_TOOLS` env var (comma-separated)
+- Supports exact match (`Read`), wildcard prefix (`filesystem.*`), and catch-all (`*`)
+- Case-sensitive matching
+- Empty allowlist blocks everything (deny-by-default)
+- Non-allowlisted tools return a structured JSON-RPC error with reason
+- Malformed/null config blocks everything defensively
+
+## Connection Architecture
+
+```
+Docker Sandbox (sbx)                    Host Machine
+┌──────────────────┐   JSON-RPC/HTTP   ┌──────────────────────┐
+│ AI Agent         ├──────────────────►│ MCP Proxy :18923     │
+│ (Claude Code)    │                   │  ├─ allowlist         │
+│                  │◄──────────────────┤  ├─ path guard        │
+│ host.docker.     │   filtered resp   │  ├─ sanitizer         │
+│ internal:18923   │                   │  └─ audit log         │
+└──────────────────┘                   │         │ stdio       │
+                                       │  ┌──────▼─────────┐  │
+                                       │  │ MCP Servers     │  │
+                                       │  │ filesystem, git │  │
+                                       │  └────────────────┘  │
+                                       └──────────────────────┘
+```

--- a/.claude/skills/observability/SKILL.md
+++ b/.claude/skills/observability/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: observability
+description: Langfuse and Grafana Cloud integration patterns
+---
+
+## Langfuse Cloud — LLM/Agent Observability
+
+- **Tier**: Hobby (free) — 50,000 units/month, 2 users, 30-day retention
+- **SDK**: `@langfuse/langfuse` TypeScript SDK
+- **Integration pattern**:
+  - Start a Langfuse **trace** when a sandbox agent session begins (trace = one agent task)
+  - Create a **span** for each MCP tool call flowing through the proxy
+  - Span fields: tool name, latency ms, sanitized arguments, result status, injection flags raised
+  - End trace when sandbox session completes
+  - Flush on process shutdown
+- **Opt-in**: Requires `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` env vars. Proxy works without them (no hard dependency).
+- **Module**: `src/observability/langfuse.ts` — startTrace, spanToolCall, endTrace helpers
+- **Upgrade path**: Core tier at $29/month if usage exceeds 50K units
+
+## Grafana Cloud — Infrastructure Observability
+
+- **Tier**: Free — 3 users, 10K metrics, 50GB logs, 50GB traces
+- **Collector**: Grafana Alloy (OTel collector) on host machine
+  - Docker integration for automatic container metrics (CPU, memory, network, disk per sandbox)
+  - Log collection from MCP proxy stdout/stderr to Grafana Loki
+- **Prometheus metrics** exposed from MCP proxy (`src/observability/metrics.ts`):
+  - `mcp_proxy_requests_total` (counter, labels: tool_name, status)
+  - `mcp_proxy_request_duration_seconds` (histogram, labels: tool_name)
+  - `mcp_proxy_injection_flags_total` (counter, labels: pattern_name)
+  - `mcp_proxy_blocked_requests_total` (counter, labels: reason — allowlist, path_traversal, injection)
+- **Endpoint**: GET `/metrics` on port 9090 (configurable via `METRICS_PORT`)
+- **Dashboards**: Import prebuilt Docker dashboard, create custom MCP proxy dashboard
+
+## Why NOT Datadog
+
+Free tier limited to 5 hosts with 1-day retention. Pricing model designed to ratchet up costs with host-based billing, custom metric charges, and high-watermark billing. Wrong economic model for a personal project with no revenue.

--- a/.claude/skills/sandbox-operations/SKILL.md
+++ b/.claude/skills/sandbox-operations/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: sandbox-operations
+description: Docker Sandbox sbx commands, agent types, and network policies
+---
+
+## sbx Basics
+
+sbx (Docker Sandbox) provides microVM-isolated sandbox environments for AI agents. Each sandbox gets its own Docker daemon, filesystem, and network.
+
+### Available Agents
+`claude`, `codex`, `copilot`, `docker-agent`, `gemini`, `kiro`, `opencode`, `shell`
+
+### Key Commands
+```bash
+sbx run claude .                    # Create + start Claude Code sandbox in current dir
+sbx run shell .                     # Plain shell sandbox
+sbx create --name NAME claude .     # Create without starting
+sbx exec -it NAME bash              # Shell into running sandbox
+sbx exec -w /path NAME cmd          # Run command with explicit workdir
+sbx exec -e KEY=VAL NAME cmd        # Inject env vars
+sbx stop NAME && sbx rm NAME        # Clean up
+sbx ls                              # List all sandboxes
+sbx save NAME tag:version           # Snapshot as reusable template
+sbx create -t tag:version claude .  # Use custom template
+```
+
+### Workspace Mounting
+- Workspace mounts automatically from the path given to `sbx create/run`
+- Inside sandbox: workspace at `/home/agent/workspace` (claude agent) or full host path via `-w`
+- Direct mount — file changes are immediately visible both directions
+
+### Network Policies
+```bash
+sbx policy set-default balanced     # Options: allow-all, balanced, deny-all
+sbx policy allow network "host.docker.internal:18923"  # Allow specific host:port
+sbx policy deny network "evil.com:443"                 # Block specific host
+sbx policy ls                       # List all policies
+sbx policy rm network --resource "host.docker.internal:18923"  # Remove policy
+```
+Default `balanced` allows AI services, package managers, code repos, cloud infra.
+
+### Secrets
+```bash
+sbx secret set -g github            # Store GitHub token globally
+sbx secret set -g anthropic         # Store Anthropic key globally
+sbx secret ls                       # List stored secrets
+```
+Secrets are proxied — never exposed directly to the agent inside the sandbox.
+
+### Template System
+sbx does NOT consume devcontainer.json. It has its own internal base images (Ubuntu 25.10, Node 20, Python 3.13, Claude Code 2.1 as of v0.23.0). Custom templates are created by snapshotting a configured sandbox with `sbx save`.
+
+### Platform Support
+- macOS Apple Silicon: supported
+- Windows 11: supported
+- Linux: **NOT supported** (AWS mode uses plain Docker + iptables instead)
+
+### Important Notes
+- Sandboxes persist after agent exits — always `sbx stop` + `sbx rm` to clean up
+- Claude Code runs in `bypassPermissions` mode inside sandboxes by default
+- All traffic proxied through `gateway.docker.internal:3128` for policy enforcement
+- `host.docker.internal` resolves to host — used for MCP proxy connectivity
+- Git credentials need `sbx secret set -g github` for push from inside sandbox

--- a/.claude/skills/security-testing/SKILL.md
+++ b/.claude/skills/security-testing/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: security-testing
+description: Injection prevention patterns, CVE references, and test-first security workflow
+---
+
+## Injection Pattern Categories
+
+We test for these attack vectors in MCP tool responses and requests:
+
+1. **Prompt injection via tool responses** — "ignore previous instructions", "you are now", "disregard", "forget" + role override phrases
+2. **Zero-width unicode smuggling** — U+200B (ZWSP), U+200C (ZWNJ), U+200D (ZWJ), U+FEFF (BOM), U+2060 (Word Joiner) hiding instructions between visible characters
+3. **Base64-encoded payloads** — Base64 strings that decode to known injection phrases (only flags dangerous decoded content, not all base64)
+4. **Path traversal** — `../`, encoded variants (`%2f`, `%5c`, double-encoded, overlong UTF-8, fullwidth), null bytes, symlink following
+5. **Markdown/HTML injection** — `<script>`, event handlers, `<iframe>`, `javascript:` protocol, markdown image exfiltration, CSS url() exfiltration
+6. **System prompt override** — Fake turn boundaries (`<|system|>`, `<|assistant|>`, `[SYSTEM]`), tool definition injection, function_call injection, tool_result XML escape
+
+## Reference CVEs
+
+- **CVE-2025-6514** (mcp-remote, CVSS 9.6) — Arbitrary OS command execution via crafted `authorization_endpoint` URLs. Discovered by JFrog Security Research. Demonstrates that injected tool/function definitions in MCP responses can trigger code execution.
+- **CVE-2025-53110** (Filesystem MCP Server) — Directory containment bypass. Attacker can escape the allowed directory boundary through crafted path arguments.
+- **CVE-2025-53109** (Filesystem MCP Server) — Symlink traversal bypass. Attacker creates symlinks inside allowed directory pointing outside, then accesses files through the symlink.
+
+## Source Material
+
+- OWASP Top 10 for LLM Applications (2025)
+- MCP specification security considerations section
+- invariantlabs.ai published MCP attack vector research
+- Published blog posts on MCP injection techniques
+
+## Test-First Workflow
+
+1. **Red**: Write failing tests in `tests/injection-patterns.test.ts`, `tests/sanitizer.test.ts`, `tests/path-guard.test.ts` that define expected detection behavior
+2. **Green**: Implement patterns in `src/security/injection-patterns.ts` and sanitizer in `src/mcp-proxy/sanitizer.ts` to make tests pass
+3. **Verify**: Run `npx vitest run` — all tests must pass. Include false-positive tests with clean content.
+
+## Clean-Room Requirement
+
+All patterns MUST be sourced from public research (OWASP, MCP spec, published CVEs, public blog posts). NEVER port patterns from any employer's codebase (Ren, Wake, or any other). This is a legal and IP separation requirement.

--- a/claude.md
+++ b/claude.md
@@ -1,136 +1,66 @@
-# Agent Sandbox Platform — CLAUDE.md
+# agentic-press
 
-## Project Identity
-- **Name**: agentic-press (working name)
-- **Owner**: JZ (personal project, pre-employment IP — all commits must predate any employment agreement)
-- **License**: MIT
-- **Repo**: GitHub under JZ's personal account
-- **Goal**: An open-source orchestration layer that adds mediated MCP access and injection prevention to Docker Sandbox (sbx) for secure multi-agent AI coding workflows.
+Thin orchestration layer on top of Docker Sandbox (sbx). Adds MCP proxy with security filtering, audit logging, and tool allowlisting. Wraps sbx — never reimplements it.
 
-## What This Project IS and IS NOT
-- **IS**: A thin layer on top of Docker Sandbox (sbx) that adds MCP proxy with security filtering, audit logging, and orchestration glue for OMC
-- **IS NOT**: A replacement for sbx, a custom container runtime, a reimplementation of sandbox lifecycle management, or a web UI
+## Commands
 
-## Architecture Summary
+```bash
+npm run build        # Compile TypeScript
+npm test             # Run all tests (Vitest)
+npm run typecheck    # Type check without emitting
+npm run dev          # Start MCP proxy (tsx)
+./scripts/sandbox-run.sh  # Full integration test (proxy + sbx sandbox)
+```
 
-### Platform Strategy
-- **macOS (Apple Silicon) + Windows 11 — Local Dev Mode**:
-  - Docker Sandbox (`sbx`) provides microVM isolation per agent worker
-  - `sbx` has its own template system for environment definitions (NOT devcontainer.json)
-  - Each sandbox gets its own Docker daemon, filesystem, and network
-  - sbx natively supports Claude Code, Codex, Gemini CLI, Copilot CLI, Kiro, OpenCode
-  - Our layer adds: MCP proxy with injection filtering, audit logging, OMC integration
+## Code Style
 
-- **AWS Linux — Headless Mode (Phase 2)**:
-  - ECS Fargate provides task-level isolation (Fargate runs on Firecracker internally — AWS manages this, we don't nest our own Firecracker)
-  - Plain Docker containers with Anthropic's reference devcontainer firewall (iptables default-deny)
-  - Isolation is namespace-level, NOT microVM — this is a known gap vs local dev mode
-  - If stronger isolation is needed later: EC2 .metal instances with self-managed Firecracker
-  - Queue-driven: SQS → Lambda dispatcher → ephemeral Fargate task → PR → destroy
-  - NOTE: sbx does NOT support Linux today. AWS mode uses different container approach.
+- TypeScript, functions and composition over classes
+- Tests in `tests/` directory (Vitest, `*.test.ts`)
+- Conventional commits: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`
+- Config via environment variables (`.env.example`)
+- Error handling: fail loudly, structured error messages
 
-### Shared Base Image
-- Same Dockerfile base layer across local and AWS (Ubuntu 24.04, Node.js 22, Python 3.12, Claude Code)
-- Local dev: Dockerfile registered as an sbx template via `sbx template`
-- AWS headless: Same Dockerfile used directly with Docker/Fargate
-- NOT a universal config spec — platform-specific wrappers around a shared image
+## Security Requirements (NON-NEGOTIABLE)
 
-### MCP Proxy Architecture (This is our primary value-add)
-- MCP servers run on the HOST (filesystem, git, github, custom servers)
-- MCP proxy server runs on the HOST, exposes selected MCP tools over HTTP
-- Sandboxed agents connect to MCP proxy via host networking (host.docker.internal or Docker network)
-- Proxy layer implements:
-  - Tool allowlisting (configurable per-sandbox — only expose specific MCP tools)
-  - Request/response sanitization with injection prevention patterns
-  - Workspace path restriction (prevent path traversal outside mounted workspace)
-  - Full audit logging (timestamp, tool name, sanitized arguments, result status)
-- Agents CANNOT access MCP servers directly — all access is mediated through the proxy
-
-### Observability (Phase 1.5 — after integration test passes)
-- **LLM/Agent Observability — Langfuse Cloud (Free Hobby Tier)**:
-  - 50,000 units/month, 2 users, 30-day retention — sufficient for personal project
-  - Instrument MCP proxy to emit Langfuse traces per agent session
-  - Each MCP tool call becomes a span: tool name, latency, sanitized args, result status
-  - Tracks: token usage per session, MCP tool call patterns, task completion rates, cost per task
-  - Uses Langfuse TypeScript SDK (@langfuse/langfuse) — lightweight integration
-  - Upgrade path: Core tier at $29/month if usage exceeds 50K units
-
-- **Infrastructure/Container Observability — Grafana Cloud (Free Tier)**:
-  - 3 users, 10K metrics, 50GB logs, 50GB traces — sufficient for personal project
-  - Uses open standards: Prometheus metrics, OpenTelemetry, Loki for logs
-  - Grafana Alloy (OTel collector) on host collects Docker container metrics automatically
-  - Prebuilt Docker integration dashboards for container metrics and logs out of the box
-  - Tracks: sandbox startup time, container CPU/memory, MCP proxy request rate/latency, error rates, network policy violations
-  - Zero vendor lock-in — same Prometheus/OTel instrumentation works with any future platform
-
-- **Why NOT Datadog**: Free tier limited to 5 hosts with 1-day retention. Pricing model designed to ratchet up costs with host-based billing, custom metric charges, and high-watermark billing. Wrong economic model for a personal project with no revenue. JZ already has Datadog experience from Ren for resume purposes.
-
-### Dashboard / Control Plane (Phase 1.75 — adopt, don't build)
-- **Mission Control** (builderz-labs/mission-control): open-source, self-hosted agent orchestration dashboard
-- **WARNING: Alpha software** — APIs, schemas, and config formats may change between releases. Pin to a release tag.
-- Provides: Kanban task board, real-time session tracking, token/cost dashboards, memory browser, skill management
-- Integration surface: adapter layer for agent frameworks, Direct CLI mode, Task Bridge scanning ~/.claude/tasks/, webhooks with HMAC-SHA256, comms API
-- SQLite-based, zero external dependencies, single process
-- We integrate via its adapter layer or Direct CLI path — we do NOT fork or modify it
-- Fallback: agents-observe (simple10/agents-observe) if Mission Control integration exceeds 2-3 hours
-- Integration is opt-in — agent-sandbox works without a dashboard running
-
-### OMC Integration (Phase 2 — requires research)
-- OMC (oh-my-claudecode) runs on the HOST, not inside sandboxes
-- OMC uses tmux-based worker spawning — workers are tmux panes running CLI agents
-- Integration approach TBD: likely a wrapper script that OMC calls, which invokes `sbx run` under the hood
-- OMC does NOT have a documented plugin API for sandbox delegation — this needs investigation
-- Phase 1 works without OMC — single agent in single sandbox
-
-## Tech Stack
-- **Language**: TypeScript (MCP proxy, glue scripts)
-- **Sandbox Runtime**: Docker Sandbox (sbx) — we wrap it, not reimplement it
-- **MCP Bridging**: supergateway (TypeScript) or mcp-proxy (Python) — evaluate both as starting points
-- **LLM Observability**: Langfuse Cloud (Hobby free tier) — agent tracing, token tracking, tool call spans
-- **Infra Observability**: Grafana Cloud (free tier) — container metrics, proxy logs, dashboards via Alloy + Loki
-- **Dashboard**: Mission Control (builderz-labs/mission-control) — self-hosted, open-source agent orchestration UI
-- **Testing**: Vitest for TypeScript
-- **AWS (Phase 2)**: CDK (TypeScript), Lambda, Fargate, SQS
-
-## Security Requirements (Non-Negotiable)
-- Agents NEVER have unrestricted network access inside the sandbox
-- sbx network policies enforced (Locked Down mode as default)
-- MCP proxy MUST validate all tool calls against an allowlist before forwarding
-- Injection prevention patterns written from scratch based on public MCP security research:
-  - OWASP AI agent security guidelines
-  - MCP specification security considerations
-  - Published MCP-related CVEs:
-    - CVE-2025-6514 (mcp-remote, CVSS 9.6 — arbitrary OS command execution via crafted authorization_endpoint URLs)
-    - CVE-2025-53110 (Filesystem MCP Server — directory containment bypass)
-    - CVE-2025-53109 (Filesystem MCP Server — symlink traversal bypass)
-  - Publicly documented injection vectors: prompt injection via tool responses, role override phrases, zero-width unicode characters, base64-encoded instructions, path traversal in filesystem tool calls
-  - DO NOT port patterns from Ren/Wake to Code — write clean-room implementations after employment attorney review
-- All MCP proxy requests and responses logged for audit
+- All injection patterns are **clean-room** from public sources: OWASP Top 10 for LLM Apps, MCP spec, published CVEs
+- **DO NOT** port code from Ren or Wake — clean-room only
+- MCP proxy MUST validate all tool calls against allowlist before forwarding
+- Reference CVEs: CVE-2025-6514 (mcp-remote, CVSS 9.6), CVE-2025-53110 (directory containment bypass), CVE-2025-53109 (symlink traversal bypass)
+- Run security tests after ANY change to `src/security/` or `src/mcp-proxy/sanitizer.ts`
+- All MCP proxy requests/responses logged for audit
 - No host filesystem access from sandbox except sbx-managed workspace mount
 
-## Development Workflow (Mandatory)
-- **TDD is required** — always write failing tests first (Red), implement minimally (Green), then refactor. Claude should proactively create test frameworks and helpers to reduce developer burden.
-- **GitHub issues first** — create a GitHub issue ticket before starting any new work.
-- **Worktree isolation** — always use `git worktree` when working on feature/fix branches.
-- **Branch naming** — `<type>/<issue-number>-<2-3-word-description>` where type is: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`.
-  - Examples: `feat/27-implement-hooks`, `chore/68-update-docs`, `fix/45-fix-network-issue`
-- **Code review before merge** — every PR must be reviewed before merging. Never merge without review. Use the pr-review-toolkit agents to run a review, then address findings before requesting merge.
-- **Workflow sequence**: (1) create GitHub issue → (2) create worktree branch with correct naming → (3) write failing tests → (4) implement → (5) refactor → (6) PR back to main → (7) review → (8) address findings → (9) merge after approval.
+## Architecture Rules
 
-## Code Conventions
-- All source in `src/` with clear module boundaries
-- Tests alongside source files (`*.test.ts`)
-- Prefer functions and composition over classes
-- Error handling: fail loudly, structured error messages
-- Config via environment variables with `.env.example`
-- Conventional commits (feat:, fix:, docs:)
-- Tag milestones: v0.1.0 (sbx + proxy works), v0.2.0 (injection filtering), v0.3.0 (audit logging), v0.4.0 (Langfuse + Grafana observability), v0.5.0 (Mission Control dashboard integrated)
+- sbx handles sandbox lifecycle — we never reimplement sandbox management, container runtime, or network policies
+- MCP servers run on HOST, proxy mediates all access from sandboxed agents
+- Observability (Langfuse, Grafana) and dashboard (Mission Control) are opt-in via env vars — no hard dependencies
+- See `docs/ARCHITECTURE.md` for detailed architecture and phase planning
 
 ## What NOT to Build
-- Do NOT build sandbox lifecycle management — sbx does this
-- Do NOT build a custom container runtime — sbx does this
-- Do NOT build a custom web dashboard — adopt Mission Control instead
-- Do NOT implement auth or multi-tenancy — single-user only
-- Do NOT build OMC integration in Phase 1 — single agent first
-- Do NOT build the AWS headless mode in Phase 1 — local only
-- Do NOT port any code from Ren or Wake to Code — clean-room only
+
+- Custom sandbox manager or container runtime (sbx does this)
+- Custom web dashboard (adopt Mission Control)
+- Auth or multi-tenancy (single-user only)
+- OMC integration, AWS headless, or multi-agent (Phase 2)
+- Any code ported from Ren or Wake
+
+## Development Workflow
+
+- **TDD required**: write failing tests first → implement → refactor
+- **GitHub issues first**: create issue before starting work
+- **Worktree isolation**: use `git worktree` for feature branches
+- **Branch naming**: `<type>/<issue-number>-<description>` (e.g., `feat/7-mcp-proxy-server`)
+- **Code review before merge**: every PR reviewed via pr-review-toolkit, address findings, merge after approval
+- **Security changes**: enter Plan Mode first for any changes to `src/security/` or `src/mcp-proxy/`
+- **Workflow**: issue → branch → tests → implement → PR → review → fix → merge
+
+## Key Paths
+
+- `src/mcp-proxy/` — proxy server, allowlist, sanitizer, logger, stdio bridge
+- `src/security/` — injection patterns, path guard
+- `src/observability/` — Langfuse, Prometheus metrics
+- `src/dashboard/` — Mission Control adapter
+- `tests/` — all test files
+- `scripts/` — sbx integration scripts
+- `sbx/` — Dockerfile (Phase 2 AWS only; local uses sbx save for templates)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,113 @@
+# Architecture — agentic-press
+
+Detailed architecture, platform strategy, and phase planning for the agent-sandbox platform.
+
+## Platform Strategy
+
+### macOS (Apple Silicon) + Windows 11 — Local Dev Mode
+- Docker Sandbox (`sbx`) provides microVM isolation per agent worker
+- `sbx` has its own template system for environment definitions (NOT devcontainer.json)
+- Each sandbox gets its own Docker daemon, filesystem, and network
+- sbx natively supports Claude Code, Codex, Gemini CLI, Copilot CLI, Kiro, OpenCode
+- Our layer adds: MCP proxy with injection filtering, audit logging, orchestration glue
+
+### AWS Linux — Headless Mode (Phase 2)
+- ECS Fargate provides task-level isolation
+- Fargate runs on Firecracker internally — AWS manages this, we don't nest our own Firecracker
+- Plain Docker containers with Anthropic's reference devcontainer firewall (iptables default-deny)
+- Isolation is namespace-level, NOT microVM — this is a known gap vs local dev mode
+- If stronger isolation needed: EC2 .metal instances with self-managed Firecracker
+- Queue-driven: SQS → Lambda dispatcher → ephemeral Fargate task → PR → destroy
+- **sbx does NOT support Linux** — AWS mode uses a different container approach entirely
+
+### Shared Base Image
+- Same Dockerfile base layer across local and AWS (Ubuntu 24.04, Node.js, Python, Claude Code)
+- Local dev: Dockerfile registered as an sbx template via `sbx save`
+- AWS headless: Same Dockerfile used directly with Docker/Fargate
+- NOT a universal config spec — platform-specific wrappers around a shared image
+
+## MCP Proxy Architecture (Primary Value-Add)
+
+```
+Docker Sandbox (sbx)                 Host Machine
+┌──────────────────────┐            ┌─────────────────────────────────────┐
+│ AI Agent             │  JSON-RPC  │  MCP Proxy Server (:18923)          │
+│ (Claude Code, etc.)  ├───────────►│  ┌─────────────────────────────┐   │
+│                      │  over HTTP │  │ 1. Allowlist check           │   │
+│ Connects via         │            │  │ 2. Path guard                │   │
+│ host.docker.         │            │  │ 3. Forward to MCP server     │   │
+│ internal:18923       │            │  │ 4. Sanitize response         │   │
+│                      │◄───────────┤  │ 5. Audit log                 │   │
+│                      │  filtered  │  └──────────────┬──────────────┘   │
+└──────────────────────┘  response  │                 │ stdio            │
+                                    │  ┌──────────────▼──────────────┐   │
+                                    │  │ MCP Servers                  │   │
+                                    │  │ - filesystem, git, github    │   │
+                                    │  └─────────────────────────────┘   │
+                                    └─────────────────────────────────────┘
+```
+
+- MCP servers run on the HOST (filesystem, git, github, custom servers)
+- MCP proxy server runs on the HOST, exposes selected MCP tools over HTTP
+- Sandboxed agents connect via `host.docker.internal` through sbx's gateway proxy
+- Proxy layer: tool allowlisting → request/response sanitization → workspace path restriction → audit logging
+- Agents CANNOT access MCP servers directly — all access is mediated
+
+## Observability Architecture (Phase 1.5)
+
+### Langfuse Cloud — LLM/Agent Tracing
+- Hobby free tier: 50K units/month, 2 users, 30-day retention
+- Trace per agent session, span per MCP tool call
+- Tracks: token usage, tool call patterns, task completion rates, cost per task
+- SDK: `@langfuse/langfuse` TypeScript
+
+### Grafana Cloud — Infrastructure Monitoring
+- Free tier: 3 users, 10K metrics, 50GB logs, 50GB traces
+- Grafana Alloy (OTel collector) on host for Docker container metrics
+- Prometheus metrics from proxy: request count, latency, injection flags, blocked requests
+- Zero vendor lock-in — standard Prometheus/OTel
+
+### Why Not Datadog
+Free tier: 5 hosts, 1-day retention. Host-based pricing, custom metric charges, high-watermark billing. Wrong economic model for a personal project with no revenue.
+
+## Dashboard Architecture (Phase 1.75)
+
+### Mission Control (builderz-labs/mission-control)
+- Open-source, self-hosted agent orchestration dashboard
+- **Alpha software** — pin to release tag, keep adapter thin
+- Kanban board, session tracking, token/cost dashboards, memory browser
+- Integration: adapter layer, Direct CLI mode, Task Bridge, webhooks (HMAC-SHA256), comms API
+- SQLite-based, zero external dependencies
+
+### Fallback: agents-observe (simple10/agents-observe)
+- Claude Code hooks → Docker container → React dashboard
+- Real-time tool call visualization, subagent relationship trees
+- Simpler but Docker-dependent
+
+## OMC Integration (Phase 2)
+
+- OMC (oh-my-claudecode) runs on the HOST, not inside sandboxes
+- Uses tmux-based worker spawning — workers are tmux panes running CLI agents
+- Integration approach TBD: likely a wrapper script that OMC calls, which invokes `sbx run`
+- OMC does NOT have a documented plugin API for sandbox delegation — needs investigation
+- Phase 1 works without OMC — single agent in single sandbox
+
+## Phase Roadmap
+
+| Phase | Goal | Tag |
+|-------|------|-----|
+| 1 | Minimal viable sandbox: single Claude Code agent + MCP proxy | v0.1.0 |
+| 1.5 | Observability: Langfuse traces + Grafana metrics | v0.4.0 |
+| 1.75 | Dashboard: Mission Control integration | v0.5.0 |
+| 2 | OMC integration, AWS headless mode, multi-agent | TBD |
+
+## Tech Stack
+
+- **Language**: TypeScript (MCP proxy, glue scripts)
+- **Sandbox Runtime**: Docker Sandbox (sbx)
+- **MCP SDK**: `@modelcontextprotocol/sdk` + Express
+- **LLM Observability**: Langfuse Cloud
+- **Infra Observability**: Grafana Cloud (Alloy + Loki + Prometheus)
+- **Dashboard**: Mission Control
+- **Testing**: Vitest
+- **AWS (Phase 2)**: CDK, Lambda, Fargate, SQS


### PR DESCRIPTION
## Summary
- CLAUDE.md: 135 lines → 66 lines — only mistake-prevention content remains
- 5 skills created: security-testing, mcp-proxy, observability, dashboard-integration, sandbox-operations
- Security reviewer subagent (.claude/agents/security-reviewer.md)
- 3 hooks: security tests on security file edit, tsc on TS edit, vitest blocking pre-commit
- docs/ARCHITECTURE.md with full architecture, platform strategy, phase roadmap
- All content preserved — moved, not deleted

Closes #16

## Test plan
- [x] CLAUDE.md under 80 lines (66)
- [x] All skills, agents, settings.json, and docs created
- [x] No code changes — restructuring only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
