### PR TITLE
fix: dead hook, implementation status in skills, inline CVEs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'src/security/|src/mcp-proxy/sanitizer'; then npx vitest run tests/sanitizer.test.ts tests/injection-patterns.test.ts tests/path-guard.test.ts --reporter=verbose 2>&1; fi",
+            "command": "if echo \"$CLAUDE_FILE_PATH\" | grep -qE 'src/security/|src/mcp-proxy/'; then npx vitest run tests/sanitizer.test.ts tests/injection-patterns.test.ts tests/path-guard.test.ts tests/allowlist.test.ts --reporter=verbose 2>&1; fi",
             "timeout": 30000
           },
           {
@@ -23,7 +23,7 @@
           {
             "type": "command",
             "command": "npx vitest run --reporter=verbose 2>&1",
-            "timeout": 60000,
+            "timeout": 120000,
             "blocking": true
           }
         ]

--- a/.claude/skills/dashboard-integration/SKILL.md
+++ b/.claude/skills/dashboard-integration/SKILL.md
@@ -3,6 +3,10 @@ name: dashboard-integration
 description: Mission Control integration patterns and time-box rules
 ---
 
+## Implementation Status
+- **Not yet implemented**: All dashboard modules are stubs (`src/dashboard/adapter.ts`, `event-bridge.ts`, `config.ts` all throw "Not implemented")
+- **Next**: Issue #11 — Mission Control integration (time-boxed to 2-3 hours)
+
 ## Mission Control (builderz-labs/mission-control)
 
 **WARNING: Alpha software** — APIs, database schemas, and config formats may change between releases. Pin to a specific release tag. Keep the adapter thin so breaking changes upstream don't cascade.

--- a/.claude/skills/mcp-proxy/SKILL.md
+++ b/.claude/skills/mcp-proxy/SKILL.md
@@ -3,6 +3,11 @@ name: mcp-proxy
 description: MCP proxy architecture, JSON-RPC bridging, and allowlist design
 ---
 
+## Implementation Status
+- **Implemented**: Allowlist (`src/mcp-proxy/allowlist.ts`), sanitizer (`src/mcp-proxy/sanitizer.ts`), logger types (`src/mcp-proxy/logger.ts` — stub)
+- **Not yet implemented**: HTTP server (`server.ts` — stub), stdio bridge (`stdio-bridge.ts` — stub), entry point (`index.ts` — calls unimplemented createProxyServer)
+- **Next**: Issue #7 — MCP proxy server and stdio bridge
+
 ## Proxy Role
 
 HTTP server running on the HOST machine, accepting JSON-RPC 2.0 MCP protocol requests from sandboxed agents over HTTP. Sandboxed agents connect via `host.docker.internal:18923` (configurable via `MCP_PROXY_PORT` env var).

--- a/.claude/skills/observability/SKILL.md
+++ b/.claude/skills/observability/SKILL.md
@@ -3,6 +3,11 @@ name: observability
 description: Langfuse and Grafana Cloud integration patterns
 ---
 
+## Implementation Status
+- **Not yet implemented**: All observability modules are stubs (`src/observability/langfuse.ts`, `metrics.ts`, `config.ts` all throw "Not implemented")
+- **No SDK dependencies yet**: @langfuse/langfuse and prom-client are not in package.json
+- **Next**: Issue #9 (Langfuse), Issue #10 (Prometheus metrics)
+
 ## Langfuse Cloud — LLM/Agent Observability
 
 - **Tier**: Hobby (free) — 50,000 units/month, 2 users, 30-day retention

--- a/.claude/skills/sandbox-operations/SKILL.md
+++ b/.claude/skills/sandbox-operations/SKILL.md
@@ -3,6 +3,12 @@ name: sandbox-operations
 description: Docker Sandbox sbx commands, agent types, and network policies
 ---
 
+## Implementation Status
+- **Verified**: sbx v0.23.0 CLI fully tested — create, exec, ports, policies, secrets, save all working
+- **Not yet implemented**: Custom sbx template (`scripts/setup-sbx-template.sh` exists but untested), integration test (`scripts/sandbox-run.sh` — stub)
+- **Next**: Issue #8 — sbx template and end-to-end integration test
+- **Note**: Version info (Ubuntu 25.10, Node 20, Python 3.13) was accurate as of 2026-04-05. Run `sbx exec NAME bash -c 'cat /etc/os-release && node -v'` to verify current versions.
+
 ## sbx Basics
 
 sbx (Docker Sandbox) provides microVM-isolated sandbox environments for AI agents. Each sandbox gets its own Docker daemon, filesystem, and network.

--- a/.claude/skills/security-testing/SKILL.md
+++ b/.claude/skills/security-testing/SKILL.md
@@ -3,6 +3,10 @@ name: security-testing
 description: Injection prevention patterns, CVE references, and test-first security workflow
 ---
 
+## Implementation Status
+- **Implemented**: Injection patterns (17 patterns, 5 categories), sanitizer (flag/strip/block modes), allowlist (exact/wildcard/catch-all), path guard (traversal, symlinks, encoded)
+- **Tests**: 178 passing — injection-patterns, sanitizer, allowlist, path-guard
+
 ## Injection Pattern Categories
 
 We test for these attack vectors in MCP tool responses and requests:

--- a/claude.md
+++ b/claude.md
@@ -25,7 +25,10 @@ npm run dev          # Start MCP proxy (tsx)
 - All injection patterns are **clean-room** from public sources: OWASP Top 10 for LLM Apps, MCP spec, published CVEs
 - **DO NOT** port code from Ren or Wake — clean-room only
 - MCP proxy MUST validate all tool calls against allowlist before forwarding
-- Reference CVEs: CVE-2025-6514 (mcp-remote, CVSS 9.6), CVE-2025-53110 (directory containment bypass), CVE-2025-53109 (symlink traversal bypass)
+- Reference CVEs:
+  - CVE-2025-6514 (mcp-remote, CVSS 9.6 — arbitrary OS command execution via crafted authorization_endpoint URLs)
+  - CVE-2025-53110 (Filesystem MCP Server — directory containment bypass)
+  - CVE-2025-53109 (Filesystem MCP Server — symlink traversal bypass)
 - Run security tests after ANY change to `src/security/` or `src/mcp-proxy/sanitizer.ts`
 - All MCP proxy requests/responses logged for audit
 - No host filesystem access from sandbox except sbx-managed workspace mount


### PR DESCRIPTION
## Summary
Follow-up fixes from PR #17 review:

1. **Dead hook fixed** — $CLAUDE_TOOL_INPUT → $CLAUDE_FILE_PATH (security tests now actually run on edit)
2. **Hook grep broadened** — covers all of src/mcp-proxy/ not just sanitizer, added allowlist.test.ts
3. **Implementation status** — all 5 SKILL.md files now have status sections marking implemented vs stubbed
4. **CVEs inlined** — full CVE descriptions back in CLAUDE.md (not just skill files)
5. **PreCommit timeout** — 60s → 120s

Closes #18

## Test plan
- [x] No code changes — config and docs only
- [x] Hook variable matches documented Claude Code env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)
