### PR TITLE
feat: initialize self-improvement system with seed learnings

### DIFF
--- a/.learnings/2026-04-05_sbx-login-for-max-auth.md
+++ b/.learnings/2026-04-05_sbx-login-for-max-auth.md
@@ -1,0 +1,23 @@
+---
+date: 2026-04-05
+category: tooling
+source: user-correction
+confidence: high
+---
+
+## What happened
+
+When `sbx run claude` was first launched, the status showed "API Usage Billing" instead of Max subscription. Without `/login`, every agent session would consume pay-per-token API billing instead of the Max subscription's included usage.
+
+## Root cause
+
+sbx doesn't inherit host-level Claude authentication. The sandbox runs its own Claude Code instance with `apiKeyHelper: "echo proxy-managed"` — the sbx proxy manages API keys, but OAuth authentication for Max subscription must be performed inside the sandbox via the `/login` command. The proxy handles the OAuth flow so credentials aren't stored in the sandbox.
+
+## Rule
+
+After creating a new `sbx claude` sandbox, always run `/login` before doing any work. Verify auth status shows Max subscription, not API Usage Billing. This is a one-time setup per sandbox — the auth persists across sandbox stop/start cycles.
+
+## Evidence
+
+- Docker Sandbox documentation on credentials
+- sbx verification session (Issue #1)

--- a/.learnings/2026-04-05_sbx-no-custom-dockerfile-templates.md
+++ b/.learnings/2026-04-05_sbx-no-custom-dockerfile-templates.md
@@ -1,0 +1,24 @@
+---
+date: 2026-04-05
+category: architecture
+source: session-retro
+confidence: high
+---
+
+## What happened
+
+We designed a `sbx/Dockerfile` and `scripts/setup-sbx-template.sh` assuming sbx consumed custom Dockerfiles via a `docker build` → `sbx template register` workflow. When we actually ran sbx v0.23.0, it only supports predefined agent types (claude, codex, copilot, docker-agent, gemini, kiro, opencode, shell). There is no `sbx template` subcommand. Custom templates are created by snapshotting a running sandbox with `sbx save`, not by building Dockerfiles.
+
+## Root cause
+
+We designed the architecture from prompt assumptions before verifying the actual CLI surface. The prompt specified `sbx create --template claude-code-docker` which doesn't exist. Step 1 (verify sbx works) caught this, but the Dockerfile and setup script had already been designed around the wrong model.
+
+## Rule
+
+Always verify sbx's actual behavior by running it before designing integration code. sbx is agent-specific, not a generic container runtime. Custom templates use `sbx save SANDBOX TAG` to snapshot, not `docker build`. The Dockerfile in `sbx/` is only for Phase 2 AWS headless mode where sbx isn't available.
+
+## Evidence
+
+- GitHub issue #1 (verify sbx CLI)
+- sbx verification report in Obsidian
+- PR #13 updated Dockerfile comments and setup script

--- a/.learnings/2026-04-05_sbx-workspace-mount-scope.md
+++ b/.learnings/2026-04-05_sbx-workspace-mount-scope.md
@@ -1,0 +1,24 @@
+---
+date: 2026-04-05
+category: architecture
+source: session-retro
+confidence: high
+---
+
+## What happened
+
+When running `sbx run claude` from a subdirectory (e.g., `/Users/jeff/code/claude-throttle`), the sandbox mounted the parent directory `/Users/jeff/code` as the workspace rather than the current directory. This means the agent has access to all sibling projects, not just the target project. The `shell` agent, by contrast, mounted the specified directory correctly.
+
+## Root cause
+
+sbx's `claude` agent template determines the workspace mount point, which may differ from what the shell agent does. The claude agent appears to walk up to find a git root or broader workspace context. This is by design for Claude Code's multi-project awareness, but has security implications for our sandbox isolation model.
+
+## Rule
+
+Be aware that `sbx claude` may mount a broader workspace than the directory you specify. Always verify the workspace path shown at sandbox startup ("Workspace: /path/to/dir") and consider the scoping implications for file access. For tighter isolation, use `sbx shell` with explicit workspace paths, or verify the mount with `sbx exec NAME bash -c 'echo $WORKSPACE_DIR'`.
+
+## Evidence
+
+- sbx verification session (Issue #1)
+- `sbx ls` output showing workspace paths
+- Environment variable `WORKSPACE_DIR` inside sandbox

--- a/.learnings/LEARNING_INDEX.md
+++ b/.learnings/LEARNING_INDEX.md
@@ -1,0 +1,9 @@
+# Learning Index
+
+Lessons learned from previous sessions. Each entry links to a detailed learning file.
+
+| Date | Category | Learning | File |
+|------|----------|---------|------|
+| 2026-04-05 | architecture | sbx does not support custom Dockerfile templates — use `sbx save` to snapshot, not `docker build` | [link](2026-04-05_sbx-no-custom-dockerfile-templates.md) |
+| 2026-04-05 | tooling | Claude Code in sbx requires `/login` for Max subscription auth — otherwise bills per-token | [link](2026-04-05_sbx-login-for-max-auth.md) |
+| 2026-04-05 | architecture | sbx claude agent may mount parent directory as workspace, not the specified subdirectory | [link](2026-04-05_sbx-workspace-mount-scope.md) |

--- a/claude.md
+++ b/claude.md
@@ -58,6 +58,10 @@ npm run dev          # Start MCP proxy (tsx)
 - **Security changes**: enter Plan Mode first for any changes to `src/security/` or `src/mcp-proxy/`
 - **Workflow**: issue → branch → tests → implement → PR → review → fix → merge
 
+## Learnings
+
+See @.learnings/LEARNING_INDEX.md for lessons learned from previous sessions.
+
 ## Key Paths
 
 - `src/mcp-proxy/` — proxy server, allowlist, sanitizer, logger, stdio bridge


### PR DESCRIPTION
## Summary
- Created `.learnings/` directory with structured learning format
- 3 seed learnings from Phase 1 discoveries:
  1. sbx does not support custom Dockerfile templates — use `sbx save` to snapshot
  2. Claude Code in sbx requires `/login` for Max subscription auth
  3. sbx claude agent may mount parent directory as workspace
- `LEARNING_INDEX.md` with table index of all learnings
- Added `@.learnings/LEARNING_INDEX.md` import to CLAUDE.md

Full self-improvement system (retrospective subagent, /retro skill, promotion workflow, docs) tracked in Issue #20 for Phase 2 implementation.

## Test plan
- [x] No code changes — documentation and config only
- [x] All learning files follow the structured format
- [x] LEARNING_INDEX.md links resolve to existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
