### PR TITLE
chore: scrub internal codenames + add SECURITY.md

### DIFF
--- a/.claude/skills/security-testing/SKILL.md
+++ b/.claude/skills/security-testing/SKILL.md
@@ -39,4 +39,4 @@ We test for these attack vectors in MCP tool responses and requests:
 
 ## Clean-Room Requirement
 
-All patterns MUST be sourced from public research (OWASP, MCP spec, published CVEs, public blog posts). NEVER port patterns from any employer's codebase (Ren, Wake, or any other). This is a legal and IP separation requirement.
+All patterns MUST be sourced from public research (OWASP, MCP spec, published CVEs, public blog posts). NEVER port patterns from any proprietary or non-public source. This is a legal and IP separation requirement.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ npm run dev          # Start MCP proxy (tsx)
 ## Security Requirements (NON-NEGOTIABLE)
 
 - All injection patterns are **clean-room** from public sources: OWASP Top 10 for LLM Apps, MCP spec, published CVEs
-- **DO NOT** port code from Ren or Wake — clean-room only
+- **DO NOT** port code from any proprietary or non-public source — clean-room only
 - MCP proxy MUST validate all tool calls against allowlist before forwarding
 - Reference CVEs:
   - CVE-2025-6514 (mcp-remote, CVSS 9.6 — arbitrary OS command execution via crafted authorization_endpoint URLs)
@@ -46,7 +46,7 @@ npm run dev          # Start MCP proxy (tsx)
 - Custom web dashboard (adopt Mission Control)
 - Auth or multi-tenancy (single-user only)
 - OMC integration, AWS headless, or multi-agent (Phase 2)
-- Any code ported from Ren or Wake
+- Any code ported from a proprietary or non-public source
 
 ## Development Workflow
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Report suspected vulnerabilities through GitHub Security Advisories:
+
+> https://github.com/zickgraf-ai/agentic-press/security/advisories/new
+
+Advisories are private until published. The maintainer will acknowledge receipt within 5 business days and coordinate disclosure timing with the reporter.
+
+For non-vulnerability security concerns (defensive hardening suggestions, observed gaps in documentation, questions about the threat model), public issues are fine — see [`docs/security.md`](docs/security.md) for what is in and out of scope.
+
+## Scope
+
+In scope:
+
+- The MCP proxy (`src/mcp-proxy/`)
+- The injection patterns and path guard (`src/security/`)
+- The stdio bridge (`src/mcp-proxy/stdio-bridge.ts`)
+- The audit logging path
+- Any sample script under `scripts/`
+
+Out of scope (report upstream):
+
+- Vulnerabilities in `sbx`, Docker, or any upstream MCP server implementation
+- Vulnerabilities in third-party dependencies (use `npm audit` and report to the package maintainer)
+
+## Supported Versions
+
+Pre-1.0. Only the `main` branch is supported. Backports to tagged releases are evaluated case-by-case after a vulnerability is confirmed.
+
+## Defense Boundary
+
+agentic-press is one layer in a defense-in-depth strategy. The threat model, mitigations, and operator responsibilities are documented in [`docs/security.md`](docs/security.md). Read that document before reporting — issues already documented as out-of-scope operator responsibilities will be closed with a pointer back to the doc.


### PR DESCRIPTION
## Summary

Two small hygiene items surfaced during the #12 documentation trial:

1. **Scrub internal codenames from tracked files** (`CLAUDE.md`, `.claude/skills/security-testing/SKILL.md`). The clean-room rule was previously phrased as "do not port code from Ren or Wake" — those names are internal employer-IP references and should not appear in a public OSS repo. Replaced with "any proprietary or non-public source," which carries the same meaning without the leak. The same scrub already landed in user-facing `docs/` via #36; this catches the remaining tracked files.
2. **Add `SECURITY.md`** establishing GitHub Security Advisories as the vulnerability disclosure path. Issue #35 broadcast a real defensive gap as a public issue, which is the wrong default channel. SECURITY.md points reporters at the private GHSA flow and clarifies what's in scope vs. out of scope (the latter linking back to `docs/security.md`).

## Test plan

- [ ] `git grep -E 'Ren\b|Wake\b'` returns no hits in tracked files
- [ ] `SECURITY.md` renders correctly on GitHub and the GHSA link resolves
- [ ] `docs/security.md` link from `SECURITY.md` resolves once #36 lands (the doc lands in that PR)

## Related

- #12 / #36 — documentation suite (where the scrub started)
- #35 — example of a security-gap issue that should have been a private GHSA, not a public issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)