### PR TITLE
feat: AUDIT_LOG_FILE env var — synchronous audit log to dedicated file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@ ALLOWED_TOOLS=filesystem.*,Read,Write,Grep,Glob
 #   output; silent for subsequent lines from that same server.
 LOG_LEVEL=info
 
+# AUDIT_LOG_FILE — optional path to a dedicated file for the NDJSON audit
+# stream. When set, audit entries are written here with synchronous writes
+# (no stream buffering, no pino interleave). Recommended for production and
+# for any workflow that captures audit data for analysis (e.g., the
+# sweep-improvements script). When unset, audit entries go to stdout
+# alongside pino diagnostics.
+# AUDIT_LOG_FILE=/var/log/agentic-press/audit.ndjson
+
 # MCP Server Definitions (JSON array)
 # MCP_SERVERS=[{"name":"filesystem","command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/workspace"]}]
 #

--- a/.improvements/README.md
+++ b/.improvements/README.md
@@ -32,17 +32,31 @@ Future categories (bridge timeout, token-heavy session, stale setup commands) pl
 
 ## Sweep
 
-Read audit log via stdin or `--input`:
+The cleanest workflow is to capture audit entries to a dedicated file via the proxy's `AUDIT_LOG_FILE` env var, then sweep that file. Synchronous writes mean no buffering surprises, and no need to filter pino diagnostics out of stdout.
 
 ```bash
-# pipe in the proxy's NDJSON audit stream
-cat audit.ndjson | npm run sweep-improvements
+# 1. start the proxy with AUDIT_LOG_FILE set (in your shell or .env)
+AUDIT_LOG_FILE=/tmp/proxy-audit.ndjson npm run dev
 
-# or read from a file
-npm run sweep-improvements -- --input audit.ndjson
+# 2. (in another terminal, after some traffic has flowed)
+npm run sweep-improvements -- --input /tmp/proxy-audit.ndjson
+```
 
+Without `AUDIT_LOG_FILE`, audit entries go to stdout interleaved with pino diagnostics. You can still sweep by filtering out the pino lines, but the dedicated-file path is recommended:
+
+```bash
+# legacy: pipe stdout through grep, then to sweep
+grep -v '"level":' /tmp/proxy-stdout.log | npm run sweep-improvements
+```
+
+Other options:
+
+```bash
 # specify directory and per-run cap (default 3)
 npm run sweep-improvements -- --dir .improvements --max 5
+
+# pipe directly via stdin (e.g., from a tail process)
+tail -f /tmp/proxy-audit.ndjson | npm run sweep-improvements
 ```
 
 Idempotent: re-running on the same day with the same evidence is a no-op (deterministic IDs from date + category + evidence key).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -12,7 +12,7 @@ See also: [`./architecture.md`](./architecture.md), [`./security.md`](./security
 | Surface  | Transport             | Status                 | Enabled by                                      |
 |----------|-----------------------|------------------------|-------------------------------------------------|
 | Logging  | pino JSON on stdout   | Implemented            | Always on; level via `LOG_LEVEL`                |
-| Audit    | NDJSON on stdout      | Implemented            | Always on (one line per tool call)              |
+| Audit    | NDJSON on stdout, or dedicated file | Implemented | Always on (one line per tool call); set `AUDIT_LOG_FILE` to redirect to a file with synchronous writes |
 | Tracing  | Langfuse SDK (HTTPS)  | Implemented            | `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY`   |
 | Metrics  | Prometheus `/metrics` | Implemented            | `METRICS_PORT` (binds to `127.0.0.1` by default; override with `METRICS_BIND`) |
 | Dashboards | Grafana / Loki      | Partial                | Metrics scrape ready; no Alloy config shipped yet |
@@ -55,9 +55,9 @@ Standard fields:
 `src/mcp-proxy/logger.ts` writes audit entries directly as one JSON object per
 line (not pino-formatted). Every request emits exactly one entry with
 `timestamp`, `tool`, `args`, `status` (`allowed`, `blocked`, `flagged`,
-`error`), `flags`, `durationMs`, and optional `errorMessage`. The audit stream
-is the source of truth for who-called-what; the pino log is operator-facing
-diagnostics.
+`error`), `flags`, `durationMs`, `direction` (`request` | `response`), and
+optional `errorMessage`. The audit stream is the source of truth for
+who-called-what; the pino log is operator-facing diagnostics.
 
 #### Destination — `AUDIT_LOG_FILE`
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -52,12 +52,31 @@ Standard fields:
 
 ### Audit log
 
-`src/mcp-proxy/logger.ts` writes audit entries directly to `process.stdout`
-(one JSON object per line, not pino-formatted). Every request emits exactly
-one entry with `timestamp`, `tool`, `args`, `status` (`allowed`, `blocked`,
-`flagged`, `error`), `flags`, `durationMs`, and optional `errorMessage`. The
-audit stream is the source of truth for who-called-what; the pino log is
-operator-facing diagnostics.
+`src/mcp-proxy/logger.ts` writes audit entries directly as one JSON object per
+line (not pino-formatted). Every request emits exactly one entry with
+`timestamp`, `tool`, `args`, `status` (`allowed`, `blocked`, `flagged`,
+`error`), `flags`, `durationMs`, and optional `errorMessage`. The audit stream
+is the source of truth for who-called-what; the pino log is operator-facing
+diagnostics.
+
+#### Destination — `AUDIT_LOG_FILE`
+
+By default, audit entries go to `process.stdout`, interleaved with pino
+diagnostics. Fine for development, awkward for capture. Set `AUDIT_LOG_FILE`
+to a path and the proxy writes audit entries there with synchronous
+`fs.writeSync` — no stream buffering, no pino interleave, no Ctrl+C race.
+Recommended for production and for any workflow that consumes the audit log
+(e.g., the [`sweep-improvements`](../.improvements/README.md) script).
+
+```dotenv
+AUDIT_LOG_FILE=/var/log/agentic-press/audit.ndjson
+```
+
+The file is opened in append mode (preserves prior session entries) and
+closed cleanly on `SIGINT`/`SIGTERM`. If the file cannot be opened (permission
+denied, missing parent directory), the proxy falls back to stdout with a
+`console.warn` — audit-log destination failure must never break the request
+path.
 
 ## Tracing (Langfuse)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,12 +33,22 @@ const log = childLogger("main");
 // AUDIT_LOG_FILE redirects audit entries to a dedicated file with synchronous
 // writes. Keeps audit data clean of pino diagnostic interleave and avoids the
 // stream-buffering / Ctrl+C race that loses entries when stdout is captured
-// to a file. When unset, audit entries continue to go to stdout (legacy
+// to a file. When unset, audit entries continue to go to stdout (default
 // behaviour, fine for development).
 const auditLogFile = process.env.AUDIT_LOG_FILE?.trim();
 if (auditLogFile) {
-  configureAuditLog({ filePath: auditLogFile });
-  log.info({ file: auditLogFile }, "Audit log writing to dedicated file");
+  const fileActive = configureAuditLog({ filePath: auditLogFile });
+  if (fileActive) {
+    log.info({ file: auditLogFile }, "Audit log writing to dedicated file");
+  } else {
+    // configureAuditLog already emitted a console.warn with the reason.
+    // Re-state at warn level through the structured logger so the failure
+    // is visible to operators ingesting JSON logs (Loki, ELK, CloudWatch).
+    log.warn(
+      { file: auditLogFile },
+      "AUDIT_LOG_FILE configured but file open failed — audit entries going to stdout"
+    );
+  }
 }
 
 const logLevel = parseLogLevel(process.env.LOG_LEVEL);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from "./mcp-proxy/transport.js";
 import { parseLogLevel } from "./types.js";
 import { childLogger } from "./logger.js";
+import { configureAuditLog, closeAuditLog } from "./mcp-proxy/logger.js";
 import { loadLangfuseConfig, loadMetricsConfig } from "./observability/config.js";
 import { createTracer, createNoopTracer, type Tracer } from "./observability/langfuse.js";
 import {
@@ -28,6 +29,17 @@ import {
 } from "./server-config.js";
 
 const log = childLogger("main");
+
+// AUDIT_LOG_FILE redirects audit entries to a dedicated file with synchronous
+// writes. Keeps audit data clean of pino diagnostic interleave and avoids the
+// stream-buffering / Ctrl+C race that loses entries when stdout is captured
+// to a file. When unset, audit entries continue to go to stdout (legacy
+// behaviour, fine for development).
+const auditLogFile = process.env.AUDIT_LOG_FILE?.trim();
+if (auditLogFile) {
+  configureAuditLog({ filePath: auditLogFile });
+  log.info({ file: auditLogFile }, "Audit log writing to dedicated file");
+}
 
 const logLevel = parseLogLevel(process.env.LOG_LEVEL);
 const serverDefs = parseServerDefs(process.env.MCP_SERVERS);
@@ -213,6 +225,10 @@ function shutdown(signal: string) {
           log.error({ err: r.reason }, "Shutdown task failed");
         }
       }
+      // Flush + close audit log fd before exit so no entries are lost.
+      // Synchronous, idempotent — safe to call even when AUDIT_LOG_FILE
+      // wasn't configured.
+      closeAuditLog();
       process.exit(0);
     });
   });

--- a/src/mcp-proxy/logger.ts
+++ b/src/mcp-proxy/logger.ts
@@ -1,3 +1,4 @@
+import { closeSync, openSync, writeSync } from "node:fs";
 import type { SanitizeFlag } from "./sanitizer.js";
 import type { AuditStatus } from "../types.js";
 
@@ -25,6 +26,87 @@ export interface AuditEntry {
   readonly errorMessage?: string;
 }
 
+/**
+ * Module-level audit-log destination state.
+ *
+ * Default: writes to `process.stdout` (interleaves with pino diagnostics —
+ * fine for development, awkward for capture).
+ *
+ * When `configureAuditLog({ filePath })` is called, opens the file in append
+ * mode and switches `logAuditEntry` to use synchronous `fs.writeSync`. This
+ * bypasses Node's stream buffering entirely so each entry hits disk before
+ * `logAuditEntry` returns — operators tailing the file (or the
+ * `sweep-improvements` script reading it) see entries immediately, with no
+ * Ctrl+C race or pino interleave.
+ *
+ * Why synchronous writes are OK on the request hot path: each audit entry is
+ * a single line of JSON (typically <2 KiB), and modern filesystems buffer
+ * small appends in the page cache. The cost is microseconds and is bounded —
+ * unlike the pino path which is async-batched and can lose entries on a
+ * forced exit.
+ */
+let auditFd: number | null = null;
+
+export interface AuditLogOptions {
+  /** Absolute or relative path. If omitted, audit entries go to stdout. */
+  readonly filePath?: string;
+}
+
+/**
+ * Configure where `logAuditEntry` writes. Pass `{ filePath }` to direct
+ * entries to a dedicated file with synchronous writes. Pass `{}` (or call
+ * `closeAuditLog`) to revert to stdout.
+ *
+ * Calling repeatedly is safe — any previously open fd is closed before the
+ * new one is opened. If the file cannot be opened (permission denied,
+ * non-existent parent, etc.) the call falls back to stdout with a
+ * `console.warn`. Audit-log destination failure must never break the
+ * request path.
+ */
+export function configureAuditLog(opts: AuditLogOptions): void {
+  if (auditFd !== null) {
+    try {
+      closeSync(auditFd);
+    } catch {
+      // best-effort — if close fails, the OS will reap on process exit
+    }
+    auditFd = null;
+  }
+  const filePath = opts.filePath?.trim();
+  if (!filePath) return;
+  try {
+    auditFd = openSync(filePath, "a");
+  } catch (err) {
+    // Use console.warn — childLogger here would create a circular import,
+    // and this is a one-shot bootstrap-time failure. Falling back to stdout
+    // is safe; the request path keeps working.
+    console.warn(
+      `[audit-log] failed to open ${filePath} — falling back to stdout: ${err instanceof Error ? err.message : String(err)}`
+    );
+    auditFd = null;
+  }
+}
+
+/**
+ * Close the audit-log file fd if open. Safe to call multiple times. After
+ * calling, subsequent `logAuditEntry` calls write to stdout.
+ */
+export function closeAuditLog(): void {
+  if (auditFd !== null) {
+    try {
+      closeSync(auditFd);
+    } catch {
+      // best-effort
+    }
+    auditFd = null;
+  }
+}
+
 export function logAuditEntry(entry: AuditEntry): void {
-  process.stdout.write(JSON.stringify(entry) + "\n");
+  const line = JSON.stringify(entry) + "\n";
+  if (auditFd !== null) {
+    writeSync(auditFd, line);
+  } else {
+    process.stdout.write(line);
+  }
 }

--- a/src/mcp-proxy/logger.ts
+++ b/src/mcp-proxy/logger.ts
@@ -30,7 +30,10 @@ export interface AuditEntry {
  * Module-level audit-log destination state.
  *
  * Default: writes to `process.stdout` (interleaves with pino diagnostics —
- * fine for development, awkward for capture).
+ * fine for development, awkward for capture). When stdout is redirected to a
+ * pipe or file, Node block-buffers writes (see `process.stdout._handle` —
+ * synchronous to a TTY, buffered to a file/pipe), and the buffer can be lost
+ * on a forced exit before it flushes.
  *
  * When `configureAuditLog({ filePath })` is called, opens the file in append
  * mode and switches `logAuditEntry` to use synchronous `fs.writeSync`. This
@@ -41,11 +44,10 @@ export interface AuditEntry {
  *
  * Why synchronous writes are OK on the request hot path: each audit entry is
  * a single line of JSON (typically <2 KiB), and modern filesystems buffer
- * small appends in the page cache. The cost is microseconds and is bounded —
- * unlike the pino path which is async-batched and can lose entries on a
- * forced exit.
+ * small appends in the page cache. The cost is microseconds and is bounded.
  */
 let auditFd: number | null = null;
+let writeFailureWarned = false;
 
 export interface AuditLogOptions {
   /** Absolute or relative path. If omitted, audit entries go to stdout. */
@@ -57,33 +59,39 @@ export interface AuditLogOptions {
  * entries to a dedicated file with synchronous writes. Pass `{}` (or call
  * `closeAuditLog`) to revert to stdout.
  *
- * Calling repeatedly is safe — any previously open fd is closed before the
- * new one is opened. If the file cannot be opened (permission denied,
- * non-existent parent, etc.) the call falls back to stdout with a
- * `console.warn`. Audit-log destination failure must never break the
- * request path.
+ * Returns `true` when the file destination is active (caller can log "writing
+ * to file"), `false` when the call fell back to stdout (caller should NOT
+ * claim file logging is active). Calling repeatedly is safe — any previously
+ * open fd is closed before the new one is opened. If the file cannot be
+ * opened (permission denied, non-existent parent, etc.) the call falls back
+ * to stdout with a `console.warn`. Audit-log destination failure must never
+ * break the request path.
  */
-export function configureAuditLog(opts: AuditLogOptions): void {
+export function configureAuditLog(opts: AuditLogOptions): boolean {
   if (auditFd !== null) {
-    try {
-      closeSync(auditFd);
-    } catch {
-      // best-effort — if close fails, the OS will reap on process exit
-    }
+    safeCloseFd(auditFd, "configureAuditLog: closing previous fd");
     auditFd = null;
   }
+  // Reset the per-fd warning gate — a fresh open deserves a fresh chance
+  // to warn on its first failure.
+  writeFailureWarned = false;
   const filePath = opts.filePath?.trim();
-  if (!filePath) return;
+  if (!filePath) return false;
   try {
     auditFd = openSync(filePath, "a");
+    return true;
   } catch (err) {
-    // Use console.warn — childLogger here would create a circular import,
-    // and this is a one-shot bootstrap-time failure. Falling back to stdout
-    // is safe; the request path keeps working.
+    // Use console.warn rather than the structured logger here — this is a
+    // bootstrap-time call (configureAuditLog runs before the request path
+    // is exercised), and reaching for the pino instance from this module
+    // would couple logger to logger ordering. console.warn is the
+    // logger-of-last-resort for bootstrap failures across this codebase
+    // (see also parseLogLevel in src/types.ts).
     console.warn(
       `[audit-log] failed to open ${filePath} — falling back to stdout: ${err instanceof Error ? err.message : String(err)}`
     );
     auditFd = null;
+    return false;
   }
 }
 
@@ -93,20 +101,48 @@ export function configureAuditLog(opts: AuditLogOptions): void {
  */
 export function closeAuditLog(): void {
   if (auditFd !== null) {
-    try {
-      closeSync(auditFd);
-    } catch {
-      // best-effort
-    }
+    safeCloseFd(auditFd, "closeAuditLog");
     auditFd = null;
+  }
+}
+
+function safeCloseFd(fd: number, context: string): void {
+  try {
+    closeSync(fd);
+  } catch (err) {
+    // The OS will reap the fd on process exit, so this is non-fatal —
+    // but log it so operators have a breadcrumb when investigating leaks.
+    console.warn(
+      `[audit-log] ${context}: closeSync failed (non-fatal, OS will reap on exit): ` +
+        `${err instanceof Error ? err.message : String(err)}`
+    );
   }
 }
 
 export function logAuditEntry(entry: AuditEntry): void {
   const line = JSON.stringify(entry) + "\n";
   if (auditFd !== null) {
-    writeSync(auditFd, line);
-  } else {
-    process.stdout.write(line);
+    try {
+      writeSync(auditFd, line);
+      return;
+    } catch (err) {
+      // CRITICAL invariant: audit-log destination failure must NEVER break
+      // the request path. ENOSPC (disk full), ESTALE (fd revoked), EDQUOT
+      // (quota exceeded), etc. — all surface here as a thrown exception
+      // from writeSync. Catch, fall back to stdout, close the now-stale fd,
+      // and warn ONCE per fd-lifetime so operators see the failure without
+      // flooding logs with one warning per request.
+      if (!writeFailureWarned) {
+        writeFailureWarned = true;
+        console.warn(
+          `[audit-log] writeSync failed — reverting to stdout for the rest of this fd lifetime: ` +
+            `${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      safeCloseFd(auditFd, "logAuditEntry: closing stale fd after write failure");
+      auditFd = null;
+      // Don't lose THIS entry — fall through to stdout.
+    }
   }
+  process.stdout.write(line);
 }

--- a/tests/logger-write-failure.test.ts
+++ b/tests/logger-write-failure.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Tests for the writeSync-failure fallback path in logAuditEntry.
+ *
+ * Isolated to its own file because mocking `node:fs` via `vi.mock` is
+ * module-wide — we don't want it leaking into the rest of the logger
+ * tests, which depend on real filesystem behavior. The hoisted spy lets
+ * us simulate ENOSPC / ESTALE / EBADF runtime failures cleanly.
+ */
+
+const { writeSyncSpy, openSyncSpy, closeSyncSpy } = vi.hoisted(() => {
+  return {
+    writeSyncSpy: vi.fn(),
+    openSyncSpy: vi.fn(),
+    closeSyncSpy: vi.fn(),
+  };
+});
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    writeSync: writeSyncSpy,
+    openSync: openSyncSpy,
+    closeSync: closeSyncSpy,
+  };
+});
+
+import {
+  logAuditEntry,
+  configureAuditLog,
+  closeAuditLog,
+  type AuditEntry,
+} from "../src/mcp-proxy/logger.js";
+
+function entry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    timestamp: "2026-04-28T01:00:00.000Z",
+    tool: "Read",
+    args: {},
+    status: "allowed",
+    flags: [],
+    durationMs: 1,
+    ...overrides,
+  };
+}
+
+describe("audit logger — writeSync runtime failure (ENOSPC/ESTALE/EBADF)", () => {
+  let tmpDir: string;
+  let logFile: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "audit-fail-"));
+    logFile = join(tmpDir, "audit.ndjson");
+    // Open returns a deterministic fd (3 — first non-stdio fd).
+    openSyncSpy.mockReturnValue(3);
+    closeSyncSpy.mockImplementation(() => {});
+    writeSyncSpy.mockReset();
+  });
+
+  afterEach(() => {
+    closeAuditLog();
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to stdout if writeSync throws (request path must not crash)", () => {
+    writeSyncSpy.mockImplementation(() => {
+      throw Object.assign(new Error("ENOSPC: no space left on device"), { code: "ENOSPC" });
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    configureAuditLog({ filePath: logFile });
+    expect(() => logAuditEntry(entry({ tool: "WriteFails" }))).not.toThrow();
+
+    // The entry must still reach SOMEWHERE — stdout is the fallback. It's
+    // written by stdoutSpy (1) AND nothing else.
+    expect(stdoutSpy).toHaveBeenCalled();
+    const written = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+    expect(written).toContain('"tool":"WriteFails"');
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("warns ONCE per fd lifetime, not once per failed write", () => {
+    writeSyncSpy.mockImplementation(() => {
+      throw new Error("ENOSPC");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    configureAuditLog({ filePath: logFile });
+    logAuditEntry(entry({ tool: "A" }));
+    logAuditEntry(entry({ tool: "B" }));
+    logAuditEntry(entry({ tool: "C" }));
+
+    // After the first failure the fd is closed and revertedto stdout, so
+    // subsequent writeSync isn't called at all. The warn count should be 1.
+    // (Plus possibly the closeSync warning if that errored — but closeSync
+    // was mocked to succeed, so it shouldn't.)
+    const writeFailureWarnings = warnSpy.mock.calls.filter((c) =>
+      typeof c[0] === "string" && c[0].includes("writeSync failed")
+    );
+    expect(writeFailureWarnings).toHaveLength(1);
+  });
+
+  it("closes the stale fd when writeSync fails (no fd leak)", () => {
+    writeSyncSpy.mockImplementation(() => {
+      throw new Error("EBADF");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    configureAuditLog({ filePath: logFile });
+    logAuditEntry(entry({ tool: "X" }));
+
+    expect(closeSyncSpy).toHaveBeenCalledWith(3);
+  });
+
+  it("subsequent entries after writeSync failure go straight to stdout (no further fd attempts)", () => {
+    let failOnce = true;
+    writeSyncSpy.mockImplementation(() => {
+      if (failOnce) {
+        failOnce = false;
+        throw new Error("ENOSPC");
+      }
+      // The fd should be closed after the first failure — if writeSync
+      // gets called again, the test will see this no-op succeed and we'd
+      // miss the regression. But the assertion below catches the leak.
+      return 42;
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    configureAuditLog({ filePath: logFile });
+    logAuditEntry(entry({ tool: "First" }));   // fails, falls back to stdout
+    logAuditEntry(entry({ tool: "Second" }));  // straight to stdout
+
+    // writeSync should only have been called once (the failing call).
+    // If the second call hit writeSync, the fd wasn't closed properly.
+    expect(writeSyncSpy).toHaveBeenCalledTimes(1);
+    expect(stdoutSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -165,7 +165,6 @@ describe("audit logger — file destination (AUDIT_LOG_FILE)", () => {
   it("appends to an existing file (preserves prior session entries)", () => {
     // Pre-populate the file with one line, then configure and write more.
     // Audit logs are append-only — operators may concatenate sessions.
-    const { writeFileSync } = require("node:fs");
     writeFileSync(logFile, '{"timestamp":"2026-04-27T00:00:00Z","tool":"Old","args":{},"status":"allowed","flags":[]}\n');
     configureAuditLog({ filePath: logFile });
     logAuditEntry(entry({ tool: "New" }));
@@ -220,10 +219,20 @@ describe("audit logger — file destination (AUDIT_LOG_FILE)", () => {
     // console.warn (equivalent to other observability fallback paths).
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
-    configureAuditLog({ filePath: "/this/path/definitely/does/not/exist/audit.ndjson" });
+    const result = configureAuditLog({ filePath: "/this/path/definitely/does/not/exist/audit.ndjson" });
     logAuditEntry(entry({ tool: "Fallback" }));
 
+    expect(result).toBe(false); // signals fallback so caller doesn't lie in logs
     expect(warnSpy).toHaveBeenCalled();
     expect(stdoutSpy).toHaveBeenCalledOnce();
   });
+
+  it("returns true when file destination is successfully active", () => {
+    expect(configureAuditLog({ filePath: logFile })).toBe(true);
+  });
+
+  it("returns false when no filePath provided (stdout default)", () => {
+    expect(configureAuditLog({})).toBe(false);
+  });
+
 });

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { logAuditEntry, type AuditEntry } from "../src/mcp-proxy/logger.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  logAuditEntry,
+  configureAuditLog,
+  closeAuditLog,
+  type AuditEntry,
+} from "../src/mcp-proxy/logger.js";
 
 describe("audit logger", () => {
   beforeEach(() => {
@@ -100,5 +108,122 @@ describe("audit logger", () => {
     const output = spy.mock.calls[0][0] as string;
     expect(output.endsWith("\n")).toBe(true);
     expect(output.split("\n").filter(Boolean)).toHaveLength(1);
+  });
+});
+
+describe("audit logger — file destination (AUDIT_LOG_FILE)", () => {
+  let tmpDir: string;
+  let logFile: string;
+
+  function entry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+    return {
+      timestamp: "2026-04-28T01:00:00.000Z",
+      tool: "Read",
+      args: {},
+      status: "allowed",
+      flags: [],
+      durationMs: 1,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "audit-test-"));
+    logFile = join(tmpDir, "audit.ndjson");
+  });
+
+  afterEach(() => {
+    closeAuditLog();
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("writes audit entries to the configured file (not stdout)", () => {
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    configureAuditLog({ filePath: logFile });
+    logAuditEntry(entry({ tool: "ToolA" }));
+    logAuditEntry(entry({ tool: "ToolB" }));
+
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    const lines = readFileSync(logFile, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).tool).toBe("ToolA");
+    expect(JSON.parse(lines[1]!).tool).toBe("ToolB");
+  });
+
+  it("uses synchronous writes — entries are visible to other readers immediately", () => {
+    // The whole point of AUDIT_LOG_FILE: no stream buffering, no pino
+    // interleave, no Ctrl+C race. Each writeSync hits disk before
+    // logAuditEntry returns.
+    configureAuditLog({ filePath: logFile });
+    logAuditEntry(entry({ tool: "Synchronous" }));
+    // Read immediately, no setTimeout / flush / process exit needed
+    const content = readFileSync(logFile, "utf8");
+    expect(content).toContain('"tool":"Synchronous"');
+  });
+
+  it("appends to an existing file (preserves prior session entries)", () => {
+    // Pre-populate the file with one line, then configure and write more.
+    // Audit logs are append-only — operators may concatenate sessions.
+    const { writeFileSync } = require("node:fs");
+    writeFileSync(logFile, '{"timestamp":"2026-04-27T00:00:00Z","tool":"Old","args":{},"status":"allowed","flags":[]}\n');
+    configureAuditLog({ filePath: logFile });
+    logAuditEntry(entry({ tool: "New" }));
+    closeAuditLog();
+
+    const lines = readFileSync(logFile, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).tool).toBe("Old");
+    expect(JSON.parse(lines[1]!).tool).toBe("New");
+  });
+
+  it("closeAuditLog reverts to stdout for subsequent entries", () => {
+    configureAuditLog({ filePath: logFile });
+    logAuditEntry(entry({ tool: "ToFile" }));
+    closeAuditLog();
+
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    logAuditEntry(entry({ tool: "ToStdout" }));
+
+    expect(stdoutSpy).toHaveBeenCalledOnce();
+    const fileContent = readFileSync(logFile, "utf8");
+    expect(fileContent).toContain('"tool":"ToFile"');
+    expect(fileContent).not.toContain('"tool":"ToStdout"');
+  });
+
+  it("calling configureAuditLog twice closes the previous fd cleanly", () => {
+    const logFile2 = join(tmpDir, "audit2.ndjson");
+    configureAuditLog({ filePath: logFile });
+    logAuditEntry(entry({ tool: "First" }));
+    configureAuditLog({ filePath: logFile2 });
+    logAuditEntry(entry({ tool: "Second" }));
+
+    expect(readFileSync(logFile, "utf8")).toContain('"tool":"First"');
+    expect(readFileSync(logFile, "utf8")).not.toContain('"tool":"Second"');
+    expect(readFileSync(logFile2, "utf8")).toContain('"tool":"Second"');
+  });
+
+  it("configureAuditLog with no filePath reverts to stdout (and closes any open fd)", () => {
+    configureAuditLog({ filePath: logFile });
+    logAuditEntry(entry({ tool: "ToFile" }));
+    configureAuditLog({}); // no filePath
+
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    logAuditEntry(entry({ tool: "ToStdout" }));
+
+    expect(stdoutSpy).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to stdout if file open fails (operability over correctness)", () => {
+    // An unwritable path shouldn't kill the proxy — audit-log destination
+    // failure must never break the request path. Fall back to stdout with a
+    // console.warn (equivalent to other observability fallback paths).
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    configureAuditLog({ filePath: "/this/path/definitely/does/not/exist/audit.ndjson" });
+    logAuditEntry(entry({ tool: "Fallback" }));
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(stdoutSpy).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary
Fixes the buffering / pino-interleave friction discovered while testing the self-improvement system end-to-end (#20). Adds an opt-in \`AUDIT_LOG_FILE\` env var that writes audit entries to a dedicated file with synchronous \`fs.writeSync\` — no stream buffering, no pino interleave, no Ctrl+C race.

## Why
While testing the sweep-improvements script against a real proxy run, audit entries emitted via \`process.stdout.write\` were lost to Node's block-buffering when stdout was redirected to a file. Even with \`script\` (PTY allocation), the SIGINT handler didn't reliably flush before \`npm run dev\`'s parent killed the process. The workaround (\`grep -v '"level":'\` plus precise Ctrl+C timing) is friction users will hit; better to fix it.

## Behavior
- **\`AUDIT_LOG_FILE\` unset**: audit entries go to stdout (legacy behaviour, unchanged)
- **\`AUDIT_LOG_FILE\` set**: opens the file in append mode (preserves prior session entries), writes each entry with \`fs.writeSync\` (synchronous), closes cleanly on SIGINT/SIGTERM
- **File open fails**: falls back to stdout with a \`console.warn\` — audit-log destination failure must never break the request path

## Smoke test result
With \`AUDIT_LOG_FILE\` set, three blocked tool calls produced three clean JSON audit lines, immediately visible to a parallel \`cat\` of the file, no Ctrl+C or grep needed. Sweep script reads the file directly without any filtering.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` passes (563 tests: 556 baseline + 7 new logger tests)
- [x] End-to-end smoke: \`AUDIT_LOG_FILE=/tmp/x npm run dev\` + curl loop + sweep against the captured file

## Files changed
- \`src/mcp-proxy/logger.ts\` — \`configureAuditLog\`, \`closeAuditLog\`, switch logAuditEntry to writeSync when fd is open
- \`src/index.ts\` — read env var at startup, wire closeAuditLog into shutdown sequence
- \`tests/logger.test.ts\` — 7 new tests covering all behavior (file write, sync visibility, append mode, close/revert, double-configure, empty path, fallback on open failure)
- \`.env.example\` — \`AUDIT_LOG_FILE\` documented with rationale
- \`docs/observability.md\` — new "Destination — AUDIT_LOG_FILE" subsection
- \`.improvements/README.md\` — sweep workflow simplified to use \`AUDIT_LOG_FILE\` as the recommended path

🤖 Generated with [Claude Code](https://claude.com/claude-code)