### PR TITLE
feat: Langfuse SDK v3 → v5 upgrade + trace enrichment

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -175,22 +175,26 @@ Observability must never break the request path. Three layers enforce that:
 3. The server additionally wraps every `span`/`end` call in `safeSpan` /
    `safeEnd` to defend against custom `Tracer` implementations.
 
-If Langfuse is unreachable mid-request, the SDK queues events in memory and
-retries on its own schedule. Individual failed calls log `span failed` /
-`end failed` / `startTrace failed` and are dropped silently from the
-operator's perspective. `end()` is idempotent at the `ActiveTrace` layer, so
-both the success and the defensive outer-catch paths can call it without
-risk of double-close. Trace flushing happens on shutdown via
-`tracer.shutdown()`.
+If Langfuse is unreachable mid-request, the OTEL `BatchSpanProcessor` inside
+`LangfuseSpanProcessor` queues spans in memory and retries export on its own
+schedule (this replaces v3's in-SDK retry behavior). Individual failed calls
+log `span failed` / `end failed` / `startTrace failed` and are dropped
+silently from the operator's perspective. `end()` is idempotent at the
+`ActiveTrace` layer, so both the success and the defensive outer-catch paths
+can call it without risk of double-close. Trace flushing happens on shutdown
+via `tracer.shutdown()`.
 
 ### Adding a traced operation
 
 1. Accept an `ActiveTrace` from the caller or start one via
-   `tracer.startTrace({ name, metadata })`.
+   `tracer.startTrace({ name, metadata, input?, sessionId?, userId?, tags? })`.
 2. Call `activeTrace.span({ tool, status, durationMs, flags })` on the
    terminal outcome of each stage.
-3. Call `activeTrace.end({ outcome, metadata? })` exactly once per trace.
-   Double-calls are safe but wasteful.
+3. Call `activeTrace.end({ outcome, output?, metadata? })` exactly once per
+   trace. Double-calls are safe but wasteful. Pass an `output` snapshot —
+   typically `{ outcome, ...context }` — so the Langfuse UI Output column
+   surfaces the terminal decision; an undefined `output` leaves the column
+   empty rather than rendering the literal string `"undefined"`.
 4. Never let a tracer exception escape. Use `safeSpan` / `safeEnd` patterns
    from `server.ts` when integrating new call sites.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -80,7 +80,11 @@ path.
 
 ## Tracing (Langfuse)
 
-Implemented in `src/observability/langfuse.ts` and `config.ts` (PR [#30](https://github.com/zickgraf-ai/agentic-press/pull/30)).
+Implemented in `src/observability/langfuse.ts` and `config.ts`. Originally
+shipped on Langfuse JS SDK v3 (PR [#30](https://github.com/zickgraf-ai/agentic-press/pull/30));
+upgraded to the OpenTelemetry-based v5 SDK packages (`@langfuse/tracing`,
+`@langfuse/client`, `@langfuse/otel`, `@opentelemetry/sdk-node`) along with
+trace enrichment in PR #49.
 
 ### Enabling
 
@@ -118,14 +122,33 @@ no-op tracer.
 ### Shape
 
 - **One trace per `/mcp` request.** Named `mcp.request:<toolName>`. Started
-  in the server handler as soon as the tool name is known.
-- **One span per pipeline decision.** Named `mcp.tool_call`, emitted on the
-  terminal decision for the request.
-- **Trace metadata**: `method`, `requestId` (JSON-RPC id), `correlationId`.
+  in the server handler as soon as the tool name is known. The trace
+  corresponds to a root OpenTelemetry observation in the v5 model.
+- **One span per pipeline decision.** A child observation named
+  `mcp.tool_call`, emitted on the terminal decision for the request and
+  ended immediately (point-in-time semantics — span() represents a stage
+  decision, not a long-running operation).
+- **Trace input**: `{ tool, requestId, method, correlationId }`. A whitelist
+  set by `server.ts` — never the raw `arguments` payload (the sanitizer's
+  threat model assumes those carry hostile content). Renders in the Langfuse
+  UI Input column for at-a-glance request identification.
+- **Trace output**: `{ outcome, ...context }` set at `end()`. Concrete
+  examples: `{outcome:"blocked", reason:"path_guard"}`,
+  `{outcome:"flagged", phase:"request", patterns:[...]}`,
+  `{outcome:"error", phase:"bridge_call"}`. Renders in the UI Output column.
+- **Trace tags**: `["status:<status>", "outcome:<outcome>"]` plus any
+  caller-provided initial tags. Use the Langfuse trace filter to slice by
+  status without cracking metadata.
+- **Trace metadata**: `method`, `requestId` (JSON-RPC id), `correlationId`,
+  plus `outcome` after end. OpenTelemetry resource attributes (host, process,
+  SDK version) are also attached automatically by `LangfuseSpanProcessor`.
 - **Span metadata**: `tool`, `status`, `durationMs`, `flags` (sanitizer
   pattern names when status is `flagged`).
-- **`sessionId`** is reserved in the API but not yet wired — see the comment
-  in `server.ts` and the `StartTraceParams` docstring.
+- **`sessionId` and `userId`** are reserved in `StartTraceParams` and propagate
+  to the trace as `session.id` and `user.id` respectively when set. Phase 1
+  leaves them undefined — Phase 2 multi-agent orchestration wires them from
+  the dispatched agent's identity, enabling per-agent grouping in the
+  Langfuse Sessions / Users views.
 
 | Stage outcome           | Span status | Trace end outcome |
 |-------------------------|-------------|-------------------|
@@ -142,9 +165,13 @@ no-op tracer.
 Observability must never break the request path. Three layers enforce that:
 
 1. `createNoopTracer()` is used whenever config is disabled. It never imports
-   the `langfuse` module, so Langfuse is a genuine optional dependency.
-2. The real tracer wraps every SDK call (`trace`, `span`, `update`,
-   `flushAsync`, `shutdownAsync`) in try/catch and logs at `warn`.
+   any `@langfuse/*` or `@opentelemetry/*` module, so observability is a
+   genuine optional dependency — a deployment without those packages installed
+   still works as long as Langfuse stays disabled.
+2. The real tracer wraps every SDK call (`startObservation`, child observation
+   creation, `update`, `end`, `flush`, `shutdown`, OTEL `sdk.shutdown`) in
+   try/catch and logs at `warn`. Each shutdown phase is wrapped independently
+   so a hang in OTEL flush never blocks a Langfuse client shutdown.
 3. The server additionally wraps every `span`/`end` call in `safeSpan` /
    `safeEnd` to defend against custom `Tracer` implementations.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       },
       "optionalDependencies": {
         "@langfuse/client": "^5.3.0",
+        "@langfuse/core": "^5.3.0",
         "@langfuse/otel": "^5.3.0",
         "@langfuse/tracing": "^5.3.0",
         "@opentelemetry/sdk-node": "^0.217.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,79 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
-        "langfuse": "^3.38.20",
+        "@langfuse/client": "^5.3.0",
+        "@langfuse/otel": "^5.3.0",
+        "@langfuse/tracing": "^5.3.0",
+        "@opentelemetry/sdk-node": "^0.217.0",
         "prom-client": "^15.1.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
@@ -46,6 +117,74 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
@@ -58,6 +197,278 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -231,6 +642,64 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/protobufjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.12",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
@@ -302,6 +771,77 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@langfuse/client": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/client/-/client-5.3.0.tgz",
+      "integrity": "sha512-e+1LZREKWyegy1fcZzFKlMOJqMkqiK8fDE42o0EK+blmNROtpQff/LrDr9k1pfXznStSnLplwp5bdEehIvpy+g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@langfuse/core": "^5.3.0",
+        "@langfuse/tracing": "^5.3.0",
+        "mustache": "^4.2.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@langfuse/core": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/core/-/core-5.3.0.tgz",
+      "integrity": "sha512-9JnDpSMBxsy6Mw5YTc0vERpAYJG5jJKxLtgv1mgA4yrNGWOtqV6ShkSSb/mWE7CeyKFnIFM0lRJpqblrMaRfQA==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@langfuse/otel": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/otel/-/otel-5.3.0.tgz",
+      "integrity": "sha512-CJUz3oCD0RMbe+1cPxnuLD/JhsUnLt02DhLP6ZXzhFoi07rHsf8T5oUyCwLRNRH4x2tl87u3aTiOcBJqSK6/fQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@langfuse/core": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.0.1",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.202.0 <1.0.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.1"
+      }
+    },
+    "node_modules/@langfuse/tracing": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.3.0.tgz",
+      "integrity": "sha512-Fz6da1O+OqrwG69nF1UAjdaZrYUfR+h+DyVjXJLTNhTrOCqx/jTiIVAP5A32rB07+l4ESgzfO4K222A6cdPW1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@langfuse/core": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -351,11 +891,646 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.217.0.tgz",
+      "integrity": "sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/configuration": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.217.0.tgz",
+      "integrity": "sha512-xCtrYOhBqdy6ZOMfe0Oa73ZKF+2LMhoOv4L5vmwAHVvOXUg+V3fvKuEIr9ZyD0Ow+vxllEjWO6PV1wd0DOtyvw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
+      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.217.0.tgz",
+      "integrity": "sha512-vC5S0Dc+noxD86CVtNu1+awCHPA5Kewi1Sg23ps+9lh4YifwsKXh3pe4XTNEKtUJiAcjpJ5dqStGakLbrSE+YQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/sdk-logs": "0.217.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.217.0.tgz",
+      "integrity": "sha512-KfLAdt1uilVE+3FxbgVnp2ZrzqbIawzcesnRoi+Kh9ckB5Ld5D8btUgoBvwTbdmuNx1j6b132Wsh72azq+pPNQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.217.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/sdk-logs": "0.217.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.217.0.tgz",
+      "integrity": "sha512-Se0GG/ZO24mQTlQj7zprR4pNI0nKe4lPDPBsuJmi6508b9TlZEuUd3EfyuHk6oJxzL7fGyDFYAbxNigQvRP2ZQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.217.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.217.0",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.217.0.tgz",
+      "integrity": "sha512-0GpJKnCoVaVA1rKBMVPHziznfOQlXgH72S9ktjBAF1AnAVPzX7vVEBGrhwiSxxHDAiefXk+J8znApsMb/K6Z3w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.217.0",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-metrics": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.217.0.tgz",
+      "integrity": "sha512-1zkMzzhiNJdVmLxuwkltqWGw4fOOam47bqRxmuQNjyKJe/9NmY5cIrZ4kiQV7sVGxoOgT0ZvGUfLcjvtpC/b9Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-metrics": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.217.0.tgz",
+      "integrity": "sha512-nfxt/KxVGFkjkO/M+58y1ugHu/dwPtxG4eYq0KApcQ7xk5CHzhdn+IuLZfDSvNDrJ3Uy5q++Fj/wbK7i8yryfQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.217.0",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-metrics": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.217.0.tgz",
+      "integrity": "sha512-U9MCXxJu0sBCh5aEkylYRR4xVIL8D1CW6dGwvYXbfFr0qveSorfD0XJchCAWoW6QfAAIcY/yxjf4Dj8OgkHBPw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.217.0.tgz",
+      "integrity": "sha512-fPZs2fw7veLH3pEKu8vSepUa2fQpAE2P7al6qU10aH9GrEJJ8YaPgsd5xON7by5rbcEVS71FOU2aWyK6nzB7VQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.217.0.tgz",
+      "integrity": "sha512-38YQoqtYjglz2GV94LGUN/djLvxtvGIQO68o6qAFPVshjmwSdX1F2i0c7vn3lEl1L5B/YqjB/bgKXaVx7KO+RQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.217.0.tgz",
+      "integrity": "sha512-nPV8gKHUiSuTZpQcnZU3/pBlK7crSyEGpZuh5MtWySB0vv6NNG0QvvfKitQt+Fc2Mc6qfyU54KlZcurwoTbrVg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-transformer": "0.217.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.7.1.tgz",
+      "integrity": "sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.217.0.tgz",
+      "integrity": "sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.217.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.217.0.tgz",
+      "integrity": "sha512-eYfqnB3UhKu/5frhd1R6+FprKygbhkomuaceMXDyzxbfXB9tKgZOVmjaJ02CkLA6Tdzumxl+e2H+vo2a8jiMPQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.217.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.217.0.tgz",
+      "integrity": "sha512-7RTAdZuOsCDnsyqTCG4+bDzrfnsWdzkRs7z0AVi/V3tEQx0oKeyc+OuRWYxnRsmaJXgxcmB8vb/lfxn58Dj6Ag==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/otlp-transformer": "0.217.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.217.0.tgz",
+      "integrity": "sha512-MKK8UHKFUOGAvbZRWh90MhwHG+Fxm6OROBdjKPCF+HQobjuJ/Kuf8Chs8CR45X1aqotxrMj7OxTdsXe8sXuGVA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.217.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.217.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1",
+        "protobufjs": "8.0.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.7.1.tgz",
+      "integrity": "sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.1.tgz",
+      "integrity": "sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.217.0.tgz",
+      "integrity": "sha512-BB+PcHItcZDL63dPMW+mJvwN9rk37wuIDjRxbVlg6pPDvDR/7GL7UJHbGsllgoggOoTimsKgENaWPoGch/oE1A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.217.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node": {
+      "version": "0.217.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.217.0.tgz",
+      "integrity": "sha512-K/60pSv42+NQiZKy1pAH18nYDkxltsDV4O3SJ233J0E9raU1ksyL9gsKuS8p30bYBb4AMPCfDuutHQaHYpcv0Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.217.0",
+        "@opentelemetry/configuration": "0.217.0",
+        "@opentelemetry/context-async-hooks": "2.7.1",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.217.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.217.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.217.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.217.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.217.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.217.0",
+        "@opentelemetry/exporter-prometheus": "0.217.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.217.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.217.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.217.0",
+        "@opentelemetry/exporter-zipkin": "2.7.1",
+        "@opentelemetry/instrumentation": "0.217.0",
+        "@opentelemetry/otlp-exporter-base": "0.217.0",
+        "@opentelemetry/propagator-b3": "2.7.1",
+        "@opentelemetry/propagator-jaeger": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.217.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1",
+        "@opentelemetry/sdk-trace-node": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz",
+      "integrity": "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.7.1",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.1",
@@ -369,6 +1544,76 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
@@ -397,6 +1642,216 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@types/body-parser": {
@@ -488,7 +1943,7 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -661,13 +2116,23 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -713,11 +2178,21 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -905,11 +2380,33 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -922,7 +2419,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -1066,6 +2563,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -1152,6 +2656,16 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -1630,6 +3144,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -1824,6 +3348,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -1866,6 +3406,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -1958,30 +3508,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/langfuse": {
-      "version": "3.38.20",
-      "resolved": "https://registry.npmjs.org/langfuse/-/langfuse-3.38.20.tgz",
-      "integrity": "sha512-MAmBAASSzJtmK1O9HQegA1mFsQhT8Yf+OJRGvE7FXkyv3g/eiBE0glLD0Ohg3pkxhoPdggM5SejK7ue9ctlaMA==",
-      "optional": true,
-      "dependencies": {
-        "langfuse-core": "^3.38.20"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/langfuse-core": {
-      "version": "3.38.20",
-      "resolved": "https://registry.npmjs.org/langfuse-core/-/langfuse-core-3.38.20.tgz",
-      "integrity": "sha512-zBKVmQN/1oT5VWZUBYlWzvokIlkC/6mnpgr/2atMyTeAm+jR3ia7w2iJMjlrF5/oG8ukO1s8+LDRCzJpF1QeEA==",
-      "optional": true,
-      "dependencies": {
-        "mustache": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2012,12 +3538,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -2103,6 +3643,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2457,6 +4004,31 @@
         "node": "^16 || ^18 || >=20"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
+      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2534,6 +4106,16 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2541,6 +4123,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2841,6 +4437,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3036,7 +4660,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -3280,11 +4904,84 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,10 @@
     "pino": "^10.3.1"
   },
   "optionalDependencies": {
-    "langfuse": "^3.38.20",
+    "@langfuse/client": "^5.3.0",
+    "@langfuse/otel": "^5.3.0",
+    "@langfuse/tracing": "^5.3.0",
+    "@opentelemetry/sdk-node": "^0.217.0",
     "prom-client": "^15.1.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "optionalDependencies": {
     "@langfuse/client": "^5.3.0",
+    "@langfuse/core": "^5.3.0",
     "@langfuse/otel": "^5.3.0",
     "@langfuse/tracing": "^5.3.0",
     "@opentelemetry/sdk-node": "^0.217.0",

--- a/src/mcp-proxy/server.ts
+++ b/src/mcp-proxy/server.ts
@@ -269,6 +269,12 @@ export function createProxyServer(config: ProxyServerConfig): Express {
         activeTrace = tracer.startTrace({
           name: `mcp.request:${tool}`,
           metadata: { method, requestId, correlationId },
+          // Trace-level input snapshot. Whitelist of safe fields only — never
+          // include raw `arguments` (could carry injection text or PII per the
+          // sanitizer's threat model). Operators see this as the Input column
+          // in the Langfuse UI and use it to identify the request without
+          // exposing the payload that the sanitizer is meant to gate.
+          input: { tool, requestId, method, correlationId },
         });
       } catch (err) {
         reqLog.warn({ err }, "startTrace failed");
@@ -280,7 +286,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
       if (!allowResult.allowed) {
         audit(tool, toolArgs, "blocked", [], undefined, "request", "allowlist");
         safeSpan({ tool, status: "blocked", durationMs: Date.now() - start });
-        safeEnd({ outcome: "blocked" });
+        safeEnd({ outcome: "blocked", output: { outcome: "blocked", reason: "allowlist" } });
         res.json(jsonRpcError(requestId, -32600, allowResult.reason));
         return;
       }
@@ -291,7 +297,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
         const patternStrings = sanitizeResult.flags.map((f) => f.pattern);
         audit(tool, toolArgs, "flagged", sanitizeResult.flags);
         safeSpan({ tool, status: "flagged", durationMs: Date.now() - start, flags: patternStrings });
-        safeEnd({ outcome: "flagged" });
+        safeEnd({ outcome: "flagged", output: { outcome: "flagged", phase: "request", patterns: patternStrings } });
         res.json(
           jsonRpcError(
             requestId,
@@ -309,7 +315,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
         if (!pathResult.allowed) {
           audit(tool, toolArgs, "blocked", [], undefined, "request", "path_guard");
           safeSpan({ tool, status: "blocked", durationMs: Date.now() - start });
-          safeEnd({ outcome: "blocked" });
+          safeEnd({ outcome: "blocked", output: { outcome: "blocked", reason: "path_guard" } });
           res.json(jsonRpcError(requestId, -32600, `Blocked path: ${pathResult.reason}`));
           return;
         }
@@ -319,7 +325,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
       if (!bridge || !sortedRoutes) {
         audit(tool, toolArgs, "allowed");
         safeSpan({ tool, status: "allowed", durationMs: Date.now() - start });
-        safeEnd({ outcome: "allowed" });
+        safeEnd({ outcome: "allowed", output: { outcome: "allowed", note: "no_backend_configured" } });
         res.json(jsonRpcError(requestId, -32603, `No MCP backend configured for tool "${tool}"`));
         return;
       }
@@ -328,7 +334,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
       if (!serverName) {
         audit(tool, toolArgs, "blocked", [], undefined, "request", "no_route");
         safeSpan({ tool, status: "blocked", durationMs: Date.now() - start });
-        safeEnd({ outcome: "blocked" });
+        safeEnd({ outcome: "blocked", output: { outcome: "blocked", reason: "no_route" } });
         res.json(jsonRpcError(requestId, -32600, `No route configured for tool "${tool}"`));
         return;
       }
@@ -354,7 +360,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
             reqLog.error({ server: serverName, error: rawMessage }, "Response sanitizer threw");
             audit(tool, toolArgs, "error", [], rawMessage, "response");
             safeSpan({ tool, status: "error", durationMs: Date.now() - start });
-            safeEnd({ outcome: "error" });
+            safeEnd({ outcome: "error", output: { outcome: "error", phase: "response_sanitizer" } });
             res.json(
               jsonRpcError(
                 requestId,
@@ -369,7 +375,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
             const operatorSummary = `response sanitizer: ${patternStrings.join(", ")}`;
             audit(tool, toolArgs, "flagged", respFlags, operatorSummary, "response");
             safeSpan({ tool, status: "flagged", durationMs: Date.now() - start, flags: patternStrings });
-            safeEnd({ outcome: "flagged" });
+            safeEnd({ outcome: "flagged", output: { outcome: "flagged", phase: "response", patterns: patternStrings } });
             res.json(
               jsonRpcError(
                 requestId,
@@ -381,7 +387,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
           }
           audit(tool, toolArgs, "allowed", [], undefined, "response");
           safeSpan({ tool, status: "allowed", durationMs: Date.now() - start });
-          safeEnd({ outcome: "allowed" });
+          safeEnd({ outcome: "allowed", output: { outcome: "allowed" } });
           res.json({ jsonrpc: "2.0", id: requestId, result });
         })
         .catch((err) => {
@@ -416,7 +422,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
               "Upstream response exceeded size cap"
             );
             safeSpan({ tool, status: "blocked", durationMs: Date.now() - start });
-            safeEnd({ outcome: "blocked" });
+            safeEnd({ outcome: "blocked", output: { outcome: "blocked", reason: "size_cap" } });
             res.json(
               jsonRpcError(
                 requestId,
@@ -438,7 +444,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
             reqLog.error({ err: auditErr }, "Audit logging failed");
           }
           safeSpan({ tool, status: "error", durationMs: Date.now() - start });
-          safeEnd({ outcome: "error" });
+          safeEnd({ outcome: "error", output: { outcome: "error", phase: "bridge_call" } });
           res.json(jsonRpcError(requestId, -32603, genericInternalError(correlationId)));
         });
       return; // Response handled in promise callbacks
@@ -453,7 +459,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
       // Best-effort: close any in-flight trace so we never leak an open trace
       // across requests. end() is idempotent so double-ends are harmless.
       safeSpan({ tool: toolName ?? "<unknown>", status: "error", durationMs: Date.now() - start });
-      safeEnd({ outcome: "error" });
+      safeEnd({ outcome: "error", output: { outcome: "error", phase: "outer_catch" } });
       res.status(500).json(jsonRpcError(requestId, -32603, genericInternalError(correlationId)));
     }
   });

--- a/src/observability/langfuse.ts
+++ b/src/observability/langfuse.ts
@@ -3,11 +3,13 @@ import type { LangfuseConfig } from "./config.js";
 import { childLogger } from "../logger.js";
 
 const log = childLogger("langfuse");
-// Type-only import: elided at runtime so it does not pull the `langfuse`
-// module in when tracing is disabled. `langfuse` lives in optionalDependencies,
-// but TypeScript resolves type-only imports against whatever is present in
-// node_modules at compile time, so we still get compile-time safety.
-import type { LangfuseTraceClient } from "langfuse";
+
+// Type-only imports: elided at runtime so the v5 packages do not load when
+// tracing is disabled. The packages live in optionalDependencies so a
+// non-observability deployment can run without them being installed at all.
+import type { LangfuseSpan } from "@langfuse/tracing";
+import type { LangfuseClient as LangfuseClientType } from "@langfuse/client";
+import type { NodeSDK as NodeSDKType } from "@opentelemetry/sdk-node";
 
 /**
  * Opaque, active trace session returned by `Tracer.startTrace`. Its lifecycle
@@ -33,12 +35,31 @@ export interface ActiveTrace {
 export interface StartTraceParams {
   readonly name: string;
   /**
-   * Reserved for future session grouping. Currently unused by the MCP proxy —
-   * each request is an independent trace. Kept in the type so we can wire in
-   * real session semantics (e.g. sbx session id) without a breaking change.
+   * Reserved for sbx-session correlation. Phase 1 leaves this undefined; Phase
+   * 2 multi-agent orchestration sets it from the dispatched agent's session.
+   * When set, propagates to the trace as `session.id` so operators can group
+   * all of an agent's tool-call traces in the Langfuse UI.
    */
   readonly sessionId?: string;
+  /**
+   * Reserved for agent-identity correlation. Phase 1 leaves this undefined;
+   * Phase 2 sets it from the agent type or dispatched agent id. Propagates to
+   * the trace as `user.id` for filtering and cost attribution.
+   */
+  readonly userId?: string;
   readonly metadata?: Readonly<Record<string, unknown>>;
+  /**
+   * Trace-level input snapshot rendered in the Langfuse UI. The caller is
+   * responsible for sanitization — never include raw `arguments` (could carry
+   * injection text or PII). Recommended fields: `tool`, `requestId`,
+   * `correlationId`, `method`.
+   */
+  readonly input?: unknown;
+  /**
+   * Initial trace tags. The wrapper appends `[status]` (and `blockReason` when
+   * relevant) at end() time so operators can filter by outcome.
+   */
+  readonly tags?: readonly string[];
 }
 
 export interface SpanToolCallParams {
@@ -50,6 +71,8 @@ export interface SpanToolCallParams {
 
 export interface EndTraceParams {
   readonly outcome: AuditStatus;
+  /** Output snapshot for the Langfuse UI Output column. Echo the outcome and any block reason. */
+  readonly output?: unknown;
   readonly metadata?: Readonly<Record<string, unknown>>;
 }
 
@@ -72,8 +95,8 @@ const NOOP_ACTIVE_TRACE: ActiveTrace = Object.freeze({
 
 /**
  * No-op tracer used whenever Langfuse is disabled. Importantly, this code path
- * never imports the `langfuse` module — that keeps Langfuse a true optional
- * dependency for non-observability deployments.
+ * never imports any `@langfuse/*` or `@opentelemetry/*` module — that keeps
+ * Langfuse a true optional dependency for non-observability deployments.
  */
 export function createNoopTracer(): Tracer {
   return {
@@ -91,31 +114,91 @@ export function getNoopActiveTrace(): ActiveTrace {
 /**
  * Build a tracer from a LangfuseConfig.
  *
- * Design note: `createTracer` is async so the `langfuse` SDK can be loaded via
- * dynamic `import("langfuse")` only on the enabled path. Callers in the
- * composition root `await` it once at startup; the tracer methods themselves
- * are synchronous (except flush/shutdown) so they can be called freely from
- * the request hot-path without introducing per-request promise overhead.
+ * Design note: `createTracer` is async so the v5 SDK packages are loaded via
+ * dynamic `import()` only on the enabled path. Callers in the composition
+ * root `await` it once at startup; the tracer methods themselves are
+ * synchronous (except flush/shutdown) so they can be called freely from the
+ * request hot-path without introducing per-request promise overhead.
+ *
+ * v5 SDK changes (versus v3):
+ *   - The `langfuse` package is replaced by `@langfuse/tracing` (observation
+ *     creation), `@langfuse/client` (lifecycle: flush/shutdown, scoring,
+ *     prompts), and `@langfuse/otel` (the `LangfuseSpanProcessor` that
+ *     uploads observations to Langfuse).
+ *   - Tracing is OpenTelemetry-based — the SDK requires a registered OTEL
+ *     `NodeSDK`. We register one inside this function so consumers don't
+ *     need to know about OTEL.
+ *   - `client.trace().span().update()` is replaced by `startObservation()`
+ *     returning a `LangfuseSpan` with `.update()` and `.end()`.
+ *   - Trace-level attributes (sessionId, userId, tags, input, output) are
+ *     OTEL span attributes on the root observation, set via the underlying
+ *     `otelSpan.setAttribute(...)` using the keys exported by `@langfuse/core`.
  *
  * All SDK calls inside span/end are wrapped in try/catch and failures are
- * logged via the structured logger — observability MUST NEVER break the request path.
- * This is intentional and tested.
+ * logged via the structured logger — observability MUST NEVER break the
+ * request path. This is intentional and tested.
  */
 export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
   if (!config.enabled) {
     return createNoopTracer();
   }
 
-  // Dynamic import isolates the langfuse module to the enabled code path.
-  const { Langfuse } = (await import("langfuse")) as {
-    Langfuse: new (opts: { publicKey: string; secretKey: string; baseUrl: string }) => {
-      trace: (body: Record<string, unknown>) => LangfuseTraceClient;
-      flushAsync: () => Promise<void>;
-      shutdownAsync: () => Promise<void>;
+  // Dynamic imports isolate the v5 packages to the enabled code path.
+  const tracingModule = await import("@langfuse/tracing");
+  const clientModule = await import("@langfuse/client");
+  const otelModule = await import("@langfuse/otel");
+  const sdkNodeModule = await import("@opentelemetry/sdk-node");
+
+  const {
+    startObservation,
+    setLangfuseTracerProvider,
+  } = tracingModule;
+  const { LangfuseClient } = clientModule as {
+    LangfuseClient: new (opts: { publicKey: string; secretKey: string; baseUrl: string }) => LangfuseClientType;
+  };
+  const { LangfuseSpanProcessor } = otelModule;
+  const { NodeSDK } = sdkNodeModule as { NodeSDK: new (opts: Record<string, unknown>) => NodeSDKType };
+
+  // Trace-level attribute keys from @langfuse/core. Set on the underlying OTEL
+  // span so they appear at the trace level in the Langfuse UI without
+  // requiring a propagateAttributes() callback wrapper around the request
+  // handler (which would force us to restructure server.ts).
+  const coreModule = (await import("@langfuse/core")) as {
+    LangfuseOtelSpanAttributes: {
+      TRACE_NAME: string;
+      TRACE_USER_ID: string;
+      TRACE_SESSION_ID: string;
+      TRACE_TAGS: string;
+      TRACE_INPUT: string;
+      TRACE_OUTPUT: string;
+      TRACE_METADATA: string;
     };
   };
+  const ATTR = coreModule.LangfuseOtelSpanAttributes;
 
-  const client = new Langfuse({
+  // OTEL NodeSDK setup. The LangfuseSpanProcessor batches observations and
+  // uploads them to Langfuse on flush/shutdown. Failure here means we cannot
+  // trace; we throw so the outer try/catch in src/index.ts falls back to the
+  // no-op tracer (preserves "observability never breaks startup").
+  const spanProcessor = new LangfuseSpanProcessor({
+    publicKey: config.publicKey,
+    secretKey: config.secretKey,
+    baseUrl: config.host,
+  });
+
+  const sdk = new NodeSDK({ spanProcessors: [spanProcessor] });
+  sdk.start();
+
+  // Wire the SDK's tracer provider into @langfuse/tracing so startObservation()
+  // creates spans on our processor's pipeline.
+  const provider = (sdk as unknown as { _tracerProvider?: unknown })._tracerProvider;
+  if (provider) {
+    setLangfuseTracerProvider(provider as Parameters<typeof setLangfuseTracerProvider>[0]);
+  }
+
+  // The client is only needed for lifecycle (flush, shutdown). Observation
+  // creation goes through @langfuse/tracing which uses the OTEL provider.
+  const client = new LangfuseClient({
     publicKey: config.publicKey,
     secretKey: config.secretKey,
     baseUrl: config.host,
@@ -123,13 +206,27 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
 
   return {
     startTrace(params) {
-      let traceClient: LangfuseTraceClient | undefined;
+      let rootObs: LangfuseSpan | undefined;
       try {
-        traceClient = client.trace({
-          name: params.name,
-          sessionId: params.sessionId,
+        rootObs = startObservation(params.name, {
+          input: params.input,
           metadata: params.metadata,
-        });
+        }) as LangfuseSpan;
+
+        // Trace-level attributes go on the root observation's OTEL span.
+        // Langfuse's ingestion reads these keys and lifts them onto the trace.
+        const otelSpan = (rootObs as unknown as { otelSpan: { setAttribute: (k: string, v: unknown) => void } }).otelSpan;
+        if (otelSpan) {
+          otelSpan.setAttribute(ATTR.TRACE_NAME, params.name);
+          if (params.sessionId) otelSpan.setAttribute(ATTR.TRACE_SESSION_ID, params.sessionId);
+          if (params.userId) otelSpan.setAttribute(ATTR.TRACE_USER_ID, params.userId);
+          if (params.tags && params.tags.length > 0) {
+            otelSpan.setAttribute(ATTR.TRACE_TAGS, JSON.stringify(params.tags));
+          }
+          if (params.input !== undefined) {
+            otelSpan.setAttribute(ATTR.TRACE_INPUT, safeSerialize(params.input));
+          }
+        }
       } catch (err) {
         log.warn({ err }, "startTrace failed");
         // Return the no-op sentinel so the caller doesn't need to distinguish
@@ -138,16 +235,19 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
       }
 
       let ended = false;
+      // Tags accumulated across span() calls; appended to TRACE_TAGS at end().
+      const accumulatedTags: string[] = params.tags ? [...params.tags] : [];
+
       const active: ActiveTrace = {
         span(spanParams: SpanToolCallParams) {
-          if (ended) return;
+          if (ended || !rootObs) return;
           try {
-            // `span` exists on LangfuseTraceClient at runtime; we narrow via a
-            // minimal local type so we don't rely on the full SDK surface.
-            (traceClient as unknown as {
-              span: (body: Record<string, unknown>) => unknown;
-            }).span({
-              name: "mcp.tool_call",
+            // Create a child observation `mcp.tool_call` with stage decision
+            // metadata, then end it immediately. This preserves the v3 trace
+            // tree shape (root trace + one child span) operators expect.
+            const child = (rootObs as unknown as {
+              startObservation: (name: string, attrs: Record<string, unknown>) => LangfuseSpan;
+            }).startObservation("mcp.tool_call", {
               metadata: {
                 tool: spanParams.tool,
                 status: spanParams.status,
@@ -155,19 +255,34 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
                 flags: spanParams.flags ?? [],
               },
             });
+            (child as unknown as { end: () => void }).end();
+            // Track the status as a tag on the trace.
+            accumulatedTags.push(`status:${spanParams.status}`);
           } catch (err) {
             log.warn({ err }, "span failed");
           }
         },
         end(endParams: EndTraceParams) {
-          if (ended) return;
+          if (ended || !rootObs) return;
           ended = true;
           try {
-            (traceClient as unknown as {
-              update: (body: Record<string, unknown>) => unknown;
+            // Set output and outcome metadata on the root observation, plus
+            // the final tag set, then end the root.
+            (rootObs as unknown as {
+              update: (attrs: Record<string, unknown>) => void;
             }).update({
+              output: endParams.output,
               metadata: { outcome: endParams.outcome, ...(endParams.metadata ?? {}) },
             });
+            const otelSpan = (rootObs as unknown as { otelSpan: { setAttribute: (k: string, v: unknown) => void } }).otelSpan;
+            if (otelSpan) {
+              accumulatedTags.push(`outcome:${endParams.outcome}`);
+              otelSpan.setAttribute(ATTR.TRACE_TAGS, JSON.stringify(accumulatedTags));
+              if (endParams.output !== undefined) {
+                otelSpan.setAttribute(ATTR.TRACE_OUTPUT, safeSerialize(endParams.output));
+              }
+            }
+            (rootObs as unknown as { end: () => void }).end();
           } catch (err) {
             log.warn({ err }, "end failed");
           }
@@ -177,17 +292,44 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
     },
     async flush() {
       try {
-        await client.flushAsync();
+        await (client as unknown as { flush: () => Promise<void> }).flush();
       } catch (err) {
         log.warn({ err }, "flush failed");
       }
     },
     async shutdown() {
+      // Order matters: flush the LangfuseClient first, then shut down OTEL so
+      // the span processor exports any pending observations before its
+      // queues are torn down.
       try {
-        await client.shutdownAsync();
+        await (client as unknown as { flush: () => Promise<void> }).flush();
       } catch (err) {
-        log.warn({ err }, "shutdown failed");
+        log.warn({ err }, "client flush failed during shutdown");
+      }
+      try {
+        await sdk.shutdown();
+      } catch (err) {
+        log.warn({ err }, "OTEL sdk shutdown failed");
+      }
+      try {
+        await (client as unknown as { shutdown: () => Promise<void> }).shutdown();
+      } catch (err) {
+        log.warn({ err }, "client shutdown failed");
       }
     },
   };
+}
+
+/**
+ * Best-effort serialization for OTEL attribute values, which must be primitives
+ * or arrays of primitives. Objects get JSON.stringify; failures fall through
+ * to a string marker so a non-serializable value never breaks the trace path.
+ */
+function safeSerialize(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "[unserializable]";
+  }
 }

--- a/src/observability/langfuse.ts
+++ b/src/observability/langfuse.ts
@@ -16,9 +16,9 @@ import type { NodeSDK as NodeSDKType } from "@opentelemetry/sdk-node";
  * is enforced by construction:
  *
  *   - You cannot call `span()` or `end()` without first calling `startTrace`.
- *   - `end()` is idempotent — the underlying SDK's update is called at most
- *     once, so accidental double-ends (e.g. a deep success branch plus a
- *     defensive outer catch) are safe.
+ *   - `end()` is idempotent — the underlying SDK's `update`/`end` are called
+ *     at most once on success, so accidental double-ends (e.g. a deep success
+ *     branch plus a defensive outer catch) are safe.
  *   - `span()` and `end()` each catch their own exceptions internally. A
  *     misbehaving tracer cannot surface an error back into the request path.
  *
@@ -56,8 +56,10 @@ export interface StartTraceParams {
    */
   readonly input?: unknown;
   /**
-   * Initial trace tags. The wrapper appends `[status]` (and `blockReason` when
-   * relevant) at end() time so operators can filter by outcome.
+   * Initial trace tags. The wrapper appends `status:<status>` (set when
+   * `span()` is called) and `outcome:<outcome>` (set when `end()` is called)
+   * so operators can filter traces by pipeline outcome without cracking
+   * metadata.
    */
   readonly tags?: readonly string[];
 }
@@ -112,6 +114,24 @@ export function getNoopActiveTrace(): ActiveTrace {
 }
 
 /**
+ * Runtime adapter type for the v5 `LangfuseSpan`. Consolidates the assumptions
+ * about the SDK's runtime shape into a single place so an upstream change
+ * surfaces as one type compile error rather than 15 silent runtime failures
+ * scattered across the wrapper. Reviewer suggestion S1.
+ */
+interface LangfuseSpanRuntime {
+  readonly otelSpan?: { setAttribute(key: string, value: unknown): void };
+  startObservation(name: string, attrs: Record<string, unknown>): LangfuseSpanRuntime;
+  update(attrs: Record<string, unknown>): void;
+  end(): void;
+}
+
+interface LangfuseClientRuntime {
+  flush(): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
+/**
  * Build a tracer from a LangfuseConfig.
  *
  * Design note: `createTracer` is async so the v5 SDK packages are loaded via
@@ -123,8 +143,8 @@ export function getNoopActiveTrace(): ActiveTrace {
  * v5 SDK changes (versus v3):
  *   - The `langfuse` package is replaced by `@langfuse/tracing` (observation
  *     creation), `@langfuse/client` (lifecycle: flush/shutdown, scoring,
- *     prompts), and `@langfuse/otel` (the `LangfuseSpanProcessor` that
- *     uploads observations to Langfuse).
+ *     prompts), `@langfuse/otel` (the `LangfuseSpanProcessor`), and
+ *     `@langfuse/core` (the OTEL attribute key registry).
  *   - Tracing is OpenTelemetry-based — the SDK requires a registered OTEL
  *     `NodeSDK`. We register one inside this function so consumers don't
  *     need to know about OTEL.
@@ -148,11 +168,10 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
   const clientModule = await import("@langfuse/client");
   const otelModule = await import("@langfuse/otel");
   const sdkNodeModule = await import("@opentelemetry/sdk-node");
+  // @langfuse/core exposes the OTEL attribute key registry that LangfuseSpanProcessor reads.
+  const coreModule = await import("@langfuse/core");
 
-  const {
-    startObservation,
-    setLangfuseTracerProvider,
-  } = tracingModule;
+  const { startObservation, setLangfuseTracerProvider } = tracingModule;
   const { LangfuseClient } = clientModule as {
     LangfuseClient: new (opts: { publicKey: string; secretKey: string; baseUrl: string }) => LangfuseClientType;
   };
@@ -163,7 +182,7 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
   // span so they appear at the trace level in the Langfuse UI without
   // requiring a propagateAttributes() callback wrapper around the request
   // handler (which would force us to restructure server.ts).
-  const coreModule = (await import("@langfuse/core")) as {
+  const ATTR = (coreModule as {
     LangfuseOtelSpanAttributes: {
       TRACE_NAME: string;
       TRACE_USER_ID: string;
@@ -173,8 +192,7 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
       TRACE_OUTPUT: string;
       TRACE_METADATA: string;
     };
-  };
-  const ATTR = coreModule.LangfuseOtelSpanAttributes;
+  }).LangfuseOtelSpanAttributes;
 
   // OTEL NodeSDK setup. The LangfuseSpanProcessor batches observations and
   // uploads them to Langfuse on flush/shutdown. Failure here means we cannot
@@ -190,10 +208,30 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
   sdk.start();
 
   // Wire the SDK's tracer provider into @langfuse/tracing so startObservation()
-  // creates spans on our processor's pipeline.
+  // creates spans on our LangfuseSpanProcessor's pipeline.
+  //
+  // We considered using the public `trace.getTracerProvider()` from
+  // `@opentelemetry/api` (reviewer C2), but that returns a `ProxyTracerProvider`
+  // wrapper rather than the underlying `NodeTracerProvider` that the span
+  // processor was attached to. Passing the proxy to setLangfuseTracerProvider
+  // produces a hollow tracer and traces silently fail to reach Langfuse —
+  // verified empirically. There is no public method on ProxyTracerProvider
+  // to unwrap to the delegate.
+  //
+  // So we read NodeSDK's `_tracerProvider` field directly. The leading
+  // underscore signals this is private API; if @opentelemetry/sdk-node renames
+  // or removes it in a 0.x bump, we will warn LOUDLY instead of failing
+  // silently — operators see "spans will not reach Langfuse" in stdout
+  // immediately rather than discovering empty traces hours later.
   const provider = (sdk as unknown as { _tracerProvider?: unknown })._tracerProvider;
   if (provider) {
     setLangfuseTracerProvider(provider as Parameters<typeof setLangfuseTracerProvider>[0]);
+  } else {
+    log.warn(
+      "NodeSDK._tracerProvider is undefined — spans will not reach Langfuse. " +
+        "This may indicate an incompatible @opentelemetry/sdk-node version " +
+        "(this is a private field; check the upgrade path before bumping the SDK)."
+    );
   }
 
   // The client is only needed for lifecycle (flush, shutdown). Observation
@@ -202,20 +240,34 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
     publicKey: config.publicKey,
     secretKey: config.secretKey,
     baseUrl: config.host,
-  });
+  }) as unknown as LangfuseClientRuntime;
+
+  // One-shot warning when the runtime SDK shape diverges from our adapter
+  // expectations (otelSpan is the only optional field in the adapter and
+  // the most common drift point). Keeps the per-request hot path silent.
+  let warnedMissingOtelSpan = false;
+  function maybeWarnMissingOtelSpan(rootObs: LangfuseSpanRuntime) {
+    if (!rootObs.otelSpan && !warnedMissingOtelSpan) {
+      log.warn(
+        "rootObs.otelSpan is undefined — trace enrichment (input/output/tags/sessionId/userId) " +
+          "will not be attached. This may indicate an incompatible @langfuse/tracing version."
+      );
+      warnedMissingOtelSpan = true;
+    }
+  }
 
   return {
     startTrace(params) {
-      let rootObs: LangfuseSpan | undefined;
+      let rootObs: LangfuseSpanRuntime | undefined;
       try {
         rootObs = startObservation(params.name, {
           input: params.input,
           metadata: params.metadata,
-        }) as LangfuseSpan;
+        }) as unknown as LangfuseSpanRuntime;
 
-        // Trace-level attributes go on the root observation's OTEL span.
-        // Langfuse's ingestion reads these keys and lifts them onto the trace.
-        const otelSpan = (rootObs as unknown as { otelSpan: { setAttribute: (k: string, v: unknown) => void } }).otelSpan;
+        maybeWarnMissingOtelSpan(rootObs);
+
+        const otelSpan = rootObs.otelSpan;
         if (otelSpan) {
           otelSpan.setAttribute(ATTR.TRACE_NAME, params.name);
           if (params.sessionId) otelSpan.setAttribute(ATTR.TRACE_SESSION_ID, params.sessionId);
@@ -235,7 +287,8 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
       }
 
       let ended = false;
-      // Tags accumulated across span() calls; appended to TRACE_TAGS at end().
+      // Tags accumulated across span() and end() calls; written to TRACE_TAGS
+      // at end() time. Initial caller-provided tags seed the array.
       const accumulatedTags: string[] = params.tags ? [...params.tags] : [];
 
       const active: ActiveTrace = {
@@ -245,9 +298,7 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
             // Create a child observation `mcp.tool_call` with stage decision
             // metadata, then end it immediately. This preserves the v3 trace
             // tree shape (root trace + one child span) operators expect.
-            const child = (rootObs as unknown as {
-              startObservation: (name: string, attrs: Record<string, unknown>) => LangfuseSpan;
-            }).startObservation("mcp.tool_call", {
+            const child = rootObs.startObservation("mcp.tool_call", {
               metadata: {
                 tool: spanParams.tool,
                 status: spanParams.status,
@@ -255,7 +306,7 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
                 flags: spanParams.flags ?? [],
               },
             });
-            (child as unknown as { end: () => void }).end();
+            child.end();
             // Track the status as a tag on the trace.
             accumulatedTags.push(`status:${spanParams.status}`);
           } catch (err) {
@@ -264,17 +315,16 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
         },
         end(endParams: EndTraceParams) {
           if (ended || !rootObs) return;
-          ended = true;
+          // C3 fix: only mark `ended` after the SDK calls succeed. If
+          // rootObs.update() succeeds but rootObs.end() throws, leaving
+          // `ended = false` allows server.ts's outer catch to retry; OTEL
+          // span.end() is idempotent so a retry is safe.
           try {
-            // Set output and outcome metadata on the root observation, plus
-            // the final tag set, then end the root.
-            (rootObs as unknown as {
-              update: (attrs: Record<string, unknown>) => void;
-            }).update({
+            rootObs.update({
               output: endParams.output,
               metadata: { outcome: endParams.outcome, ...(endParams.metadata ?? {}) },
             });
-            const otelSpan = (rootObs as unknown as { otelSpan: { setAttribute: (k: string, v: unknown) => void } }).otelSpan;
+            const otelSpan = rootObs.otelSpan;
             if (otelSpan) {
               accumulatedTags.push(`outcome:${endParams.outcome}`);
               otelSpan.setAttribute(ATTR.TRACE_TAGS, JSON.stringify(accumulatedTags));
@@ -282,7 +332,8 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
                 otelSpan.setAttribute(ATTR.TRACE_OUTPUT, safeSerialize(endParams.output));
               }
             }
-            (rootObs as unknown as { end: () => void }).end();
+            rootObs.end();
+            ended = true;
           } catch (err) {
             log.warn({ err }, "end failed");
           }
@@ -292,44 +343,76 @@ export async function createTracer(config: LangfuseConfig): Promise<Tracer> {
     },
     async flush() {
       try {
-        await (client as unknown as { flush: () => Promise<void> }).flush();
+        await client.flush();
       } catch (err) {
         log.warn({ err }, "flush failed");
       }
     },
     async shutdown() {
-      // Order matters: flush the LangfuseClient first, then shut down OTEL so
-      // the span processor exports any pending observations before its
-      // queues are torn down.
-      try {
-        await (client as unknown as { flush: () => Promise<void> }).flush();
-      } catch (err) {
-        log.warn({ err }, "client flush failed during shutdown");
-      }
-      try {
-        await sdk.shutdown();
-      } catch (err) {
-        log.warn({ err }, "OTEL sdk shutdown failed");
-      }
-      try {
-        await (client as unknown as { shutdown: () => Promise<void> }).shutdown();
-      } catch (err) {
-        log.warn({ err }, "client shutdown failed");
-      }
+      // Order matters: (1) client.flush() pushes any client-buffered data;
+      // (2) sdk.shutdown() force-flushes the OTEL span processor's queue so
+      // pending spans reach Langfuse before exit; (3) client.shutdown() closes
+      // the LangfuseClient. Each phase has its own per-call timeout so a
+      // single hanging upstream cannot starve later phases of the caller's
+      // global shutdown budget (reviewer I2). 1s per phase is generous for
+      // a healthy network and tight enough that the global 3s window in
+      // src/index.ts still has headroom for the other observability layers.
+      await raceWithTimeout(
+        client.flush().catch((err) => log.warn({ err }, "client.flush failed during shutdown")),
+        1000,
+        "client.flush timed out during shutdown"
+      );
+      await raceWithTimeout(
+        sdk.shutdown().catch((err) => log.warn({ err }, "OTEL sdk.shutdown failed")),
+        1000,
+        "OTEL sdk.shutdown timed out"
+      );
+      await raceWithTimeout(
+        client.shutdown().catch((err) => log.warn({ err }, "client.shutdown failed")),
+        1000,
+        "client.shutdown timed out"
+      );
     },
   };
 }
 
 /**
  * Best-effort serialization for OTEL attribute values, which must be primitives
- * or arrays of primitives. Objects get JSON.stringify; failures fall through
- * to a string marker so a non-serializable value never breaks the trace path.
+ * or arrays of primitives. Strings pass through unchanged; objects get
+ * JSON.stringify; circular refs / BigInts / non-serializable values fall
+ * through to a string marker so a non-serializable value never breaks the
+ * trace path.
  */
 function safeSerialize(value: unknown): string {
   if (typeof value === "string") return value;
   try {
     return JSON.stringify(value);
-  } catch {
+  } catch (err) {
+    // Reviewer S2: log at debug level so operators have breadcrumbs but the
+    // request path stays quiet for the common case.
+    log.debug({ err }, "safeSerialize: JSON.stringify failed");
     return "[unserializable]";
+  }
+}
+
+/**
+ * Race a promise against a timeout. Resolves on whichever finishes first; if
+ * the timeout fires first, logs a warning and resolves so the caller is not
+ * blocked. Used in shutdown to bound each phase independently — a single
+ * hanging upstream must not starve later phases of the global shutdown budget.
+ */
+async function raceWithTimeout<T>(p: Promise<T>, ms: number, message: string): Promise<void> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      log.warn({ timeoutMs: ms }, message);
+      resolve();
+    }, ms);
+    timer.unref();
+  });
+  try {
+    await Promise.race([p, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }

--- a/tests/observability/langfuse-noop-isolation.test.ts
+++ b/tests/observability/langfuse-noop-isolation.test.ts
@@ -3,45 +3,86 @@ import { describe, it, expect, vi } from "vitest";
 /**
  * I8 — Isolated test for the headline guarantee of this feature:
  *
- *   When Langfuse is disabled, the `langfuse` SDK module must NEVER be
- *   imported. That keeps Langfuse a true optional dependency and means a
- *   deployment without the SDK installed still works when tracing is off.
+ *   When Langfuse is disabled, the v5 SDK packages must NEVER be imported.
+ *   That keeps observability a true optional dependency — a deployment that
+ *   doesn't install `@langfuse/*` or `@opentelemetry/sdk-node` still works
+ *   when tracing is off.
  *
- * This test is intentionally standalone (its own file, its own mock factory,
+ * This test is intentionally standalone (its own file, its own mock factories,
  * no shared beforeEach) so the guarantee cannot be broken by test-ordering or
  * mock-state drift in other observability tests.
+ *
+ * v5 changed the package layout: the single `langfuse` package became
+ * `@langfuse/tracing`, `@langfuse/client`, `@langfuse/otel`, plus the
+ * `@opentelemetry/sdk-node` runtime requirement. We assert all four factories
+ * stay untouched on the disabled path.
  */
 
-const langfuseFactory = vi.fn(() => ({
-  Langfuse: vi.fn(function (this: { trace: () => unknown; flushAsync: () => Promise<void>; shutdownAsync: () => Promise<void> }) {
-    this.trace = () => ({});
-    this.flushAsync = async () => {};
-    this.shutdownAsync = async () => {};
+const tracingFactory = vi.fn(() => ({
+  startObservation: vi.fn(),
+  setLangfuseTracerProvider: vi.fn(),
+}));
+vi.mock("@langfuse/tracing", () => tracingFactory());
+
+const clientFactory = vi.fn(() => ({
+  LangfuseClient: vi.fn(function (this: { flush: () => Promise<void>; shutdown: () => Promise<void> }) {
+    this.flush = async () => {};
+    this.shutdown = async () => {};
   }),
 }));
+vi.mock("@langfuse/client", () => clientFactory());
 
-vi.mock("langfuse", () => langfuseFactory());
+const otelFactory = vi.fn(() => ({
+  LangfuseSpanProcessor: vi.fn(),
+}));
+vi.mock("@langfuse/otel", () => otelFactory());
+
+const sdkNodeFactory = vi.fn(() => ({
+  NodeSDK: vi.fn(function (this: { start: () => void; shutdown: () => Promise<void> }) {
+    this.start = () => {};
+    this.shutdown = async () => {};
+  }),
+}));
+vi.mock("@opentelemetry/sdk-node", () => sdkNodeFactory());
+
+const coreFactory = vi.fn(() => ({
+  LangfuseOtelSpanAttributes: {},
+}));
+vi.mock("@langfuse/core", () => coreFactory());
 
 describe("createTracer isolation (#I8)", () => {
-  it("never loads the langfuse module on the disabled path", async () => {
+  it("never loads any @langfuse/* or OTEL module on the disabled path", async () => {
     // Fresh import inside the test: because this file has no shared
-    // beforeEach mutating mock state, and because the `vi.mock("langfuse")`
-    // factory only runs when something imports "langfuse", we can assert
-    // the factory has never been called after createTracer({ enabled: false }).
+    // beforeEach mutating mock state, and because each `vi.mock(...)`
+    // factory only runs when something imports the corresponding module,
+    // we can assert the factories have never been called after
+    // createTracer({ enabled: false }).
     const { createTracer, getNoopActiveTrace } = await import(
       "../../src/observability/langfuse.js"
     );
     const tracer = await createTracer({ enabled: false });
     expect(tracer).toBeDefined();
-    // The mock factory for `langfuse` is only invoked when the module is
-    // actually imported. On the disabled path, it must not be touched.
-    expect(langfuseFactory).not.toHaveBeenCalled();
+
+    // None of the v5 SDK package factories may be invoked on the disabled path.
+    expect(tracingFactory).not.toHaveBeenCalled();
+    expect(clientFactory).not.toHaveBeenCalled();
+    expect(otelFactory).not.toHaveBeenCalled();
+    expect(sdkNodeFactory).not.toHaveBeenCalled();
+    expect(coreFactory).not.toHaveBeenCalled();
+
     // startTrace on the disabled path returns the frozen NOOP sentinel —
     // calling span/end on it is a no-op and allocates nothing.
     const active = tracer.startTrace({ name: "mcp.request:Read" });
     expect(active).toBe(getNoopActiveTrace());
     active.span({ tool: "Read", status: "allowed", durationMs: 0 });
     active.end({ outcome: "allowed" });
-    expect(langfuseFactory).not.toHaveBeenCalled();
+
+    // Re-assert post-use: the disabled tracer's methods must not lazily
+    // trigger any SDK import.
+    expect(tracingFactory).not.toHaveBeenCalled();
+    expect(clientFactory).not.toHaveBeenCalled();
+    expect(otelFactory).not.toHaveBeenCalled();
+    expect(sdkNodeFactory).not.toHaveBeenCalled();
+    expect(coreFactory).not.toHaveBeenCalled();
   });
 });

--- a/tests/observability/langfuse.test.ts
+++ b/tests/observability/langfuse.test.ts
@@ -11,42 +11,128 @@ vi.mock("../../src/logger.js", () => ({
   default: mockLogger, childLogger: vi.fn(() => mockLogger),
 }));
 
-// Mocked Langfuse SDK — we capture spies so each test can assert against them.
-const traceSpan = vi.fn();
-const traceUpdate = vi.fn();
-const traceObj = { span: traceSpan, update: traceUpdate };
-const langfuseTrace = vi.fn(() => traceObj);
-const langfuseFlushAsync = vi.fn(async () => {});
-const langfuseShutdownAsync = vi.fn(async () => {});
-const LangfuseCtor = vi.fn(function (this: any) {
-  this.trace = langfuseTrace;
-  this.flushAsync = langfuseFlushAsync;
-  this.shutdownAsync = langfuseShutdownAsync;
-});
+// ── Mock SDK shape for v5 (@langfuse/tracing + @langfuse/client + @langfuse/otel + @opentelemetry/sdk-node) ──
+//
+// startObservation(name, attributes) returns a LangfuseSpan-like object with:
+//   - .update(attrs)     — applied to root + child observations
+//   - .end()             — finalizes the observation
+//   - .startObservation(name, attrs) — creates a child (we only ever do this for `mcp.tool_call`)
+//   - .otelSpan          — the underlying OpenTelemetry span; we set TRACE_* attrs via setAttribute
+//
+// LangfuseClient has .flush() and .shutdown() for lifecycle.
+// LangfuseSpanProcessor and NodeSDK are constructed but only their start/shutdown matter for tests.
 
-const langfuseModuleFactory = vi.fn(() => ({ Langfuse: LangfuseCtor }));
-vi.mock("langfuse", () => langfuseModuleFactory());
+const otelSpanSetAttribute = vi.fn();
+const childObsEnd = vi.fn();
+const childObsUpdate = vi.fn();
+const startChildObservation = vi.fn(() => ({
+  update: childObsUpdate,
+  end: childObsEnd,
+  otelSpan: { setAttribute: vi.fn() },
+}));
+const rootObsEnd = vi.fn();
+const rootObsUpdate = vi.fn();
+
+function makeRootObs() {
+  return {
+    update: rootObsUpdate,
+    end: rootObsEnd,
+    startObservation: startChildObservation,
+    otelSpan: { setAttribute: otelSpanSetAttribute },
+  };
+}
+
+const startObservation = vi.fn(() => makeRootObs());
+const setLangfuseTracerProvider = vi.fn();
+
+const tracingFactory = vi.fn(() => ({
+  startObservation,
+  setLangfuseTracerProvider,
+}));
+vi.mock("@langfuse/tracing", () => tracingFactory());
+
+const langfuseClientFlush = vi.fn(async () => {});
+const langfuseClientShutdown = vi.fn(async () => {});
+const LangfuseClientCtor = vi.fn(function (this: any) {
+  this.flush = langfuseClientFlush;
+  this.shutdown = langfuseClientShutdown;
+});
+const clientFactory = vi.fn(() => ({ LangfuseClient: LangfuseClientCtor }));
+vi.mock("@langfuse/client", () => clientFactory());
+
+const LangfuseSpanProcessorCtor = vi.fn(function (this: any) {});
+const otelFactory = vi.fn(() => ({ LangfuseSpanProcessor: LangfuseSpanProcessorCtor }));
+vi.mock("@langfuse/otel", () => otelFactory());
+
+const sdkNodeStart = vi.fn();
+const sdkNodeShutdown = vi.fn(async () => {});
+const NodeSDKCtor = vi.fn(function (this: any) {
+  this.start = sdkNodeStart;
+  this.shutdown = sdkNodeShutdown;
+  this._tracerProvider = { __sentinel: "tracerProvider" };
+});
+const sdkNodeFactory = vi.fn(() => ({ NodeSDK: NodeSDKCtor }));
+vi.mock("@opentelemetry/sdk-node", () => sdkNodeFactory());
+
+// LangfuseOtelSpanAttributes is the OTEL key registry used to set trace-level
+// fields on the root observation. Mocked with stable strings so tests can
+// assert which key was written without depending on the upstream constants.
+const coreFactory = vi.fn(() => ({
+  LangfuseOtelSpanAttributes: {
+    TRACE_NAME: "MOCK_TRACE_NAME",
+    TRACE_USER_ID: "MOCK_TRACE_USER_ID",
+    TRACE_SESSION_ID: "MOCK_TRACE_SESSION_ID",
+    TRACE_TAGS: "MOCK_TRACE_TAGS",
+    TRACE_INPUT: "MOCK_TRACE_INPUT",
+    TRACE_OUTPUT: "MOCK_TRACE_OUTPUT",
+    TRACE_METADATA: "MOCK_TRACE_METADATA",
+  },
+}));
+vi.mock("@langfuse/core", () => coreFactory());
 
 import { createTracer, getNoopActiveTrace } from "../../src/observability/langfuse.js";
 
 beforeEach(() => {
-  traceSpan.mockReset();
-  traceUpdate.mockReset();
-  langfuseTrace.mockReset().mockReturnValue(traceObj);
-  langfuseFlushAsync.mockReset().mockResolvedValue(undefined);
-  langfuseShutdownAsync.mockReset().mockResolvedValue(undefined);
-  LangfuseCtor.mockClear();
-  langfuseModuleFactory.mockClear();
+  startObservation.mockReset().mockImplementation(() => makeRootObs());
+  startChildObservation.mockReset().mockImplementation(() => ({
+    update: childObsUpdate,
+    end: childObsEnd,
+    otelSpan: { setAttribute: vi.fn() },
+  }));
+  setLangfuseTracerProvider.mockReset();
+  rootObsEnd.mockReset();
+  rootObsUpdate.mockReset();
+  childObsEnd.mockReset();
+  childObsUpdate.mockReset();
+  otelSpanSetAttribute.mockReset();
+  langfuseClientFlush.mockReset().mockResolvedValue(undefined);
+  langfuseClientShutdown.mockReset().mockResolvedValue(undefined);
+  LangfuseClientCtor.mockClear();
+  LangfuseSpanProcessorCtor.mockClear();
+  NodeSDKCtor.mockClear();
+  sdkNodeStart.mockReset();
+  sdkNodeShutdown.mockReset().mockResolvedValue(undefined);
+  tracingFactory.mockClear();
+  clientFactory.mockClear();
+  otelFactory.mockClear();
+  sdkNodeFactory.mockClear();
+  coreFactory.mockClear();
+  mockLogger.warn.mockClear();
 });
 
 describe("createTracer (no-op mode)", () => {
   it("returns a no-op tracer immediately when disabled", async () => {
     const tracer = await createTracer({ enabled: false });
     expect(tracer).toBeDefined();
-    // No-op tracer never constructs the SDK.
-    expect(LangfuseCtor).not.toHaveBeenCalled();
-    // Module factory must not be invoked from the disabled path.
-    expect(langfuseModuleFactory).not.toHaveBeenCalled();
+    // No-op tracer never constructs the SDK or its OTEL infrastructure.
+    expect(LangfuseClientCtor).not.toHaveBeenCalled();
+    expect(LangfuseSpanProcessorCtor).not.toHaveBeenCalled();
+    expect(NodeSDKCtor).not.toHaveBeenCalled();
+    // None of the v5 module factories must be invoked from the disabled path.
+    expect(tracingFactory).not.toHaveBeenCalled();
+    expect(clientFactory).not.toHaveBeenCalled();
+    expect(otelFactory).not.toHaveBeenCalled();
+    expect(sdkNodeFactory).not.toHaveBeenCalled();
   });
 
   it("no-op tracer returns the singleton sentinel ActiveTrace and never throws", async () => {
@@ -60,161 +146,206 @@ describe("createTracer (no-op mode)", () => {
     expect(() => active.end({ outcome: "allowed" })).not.toThrow();
     await expect(tracer.flush()).resolves.toBeUndefined();
     await expect(tracer.shutdown()).resolves.toBeUndefined();
-    expect(LangfuseCtor).not.toHaveBeenCalled();
+    expect(LangfuseClientCtor).not.toHaveBeenCalled();
   });
 });
 
 describe("createTracer (enabled mode)", () => {
-  it("constructs the Langfuse SDK with credentials", async () => {
-    await createTracer({
-      enabled: true,
-      publicKey: "pk-test",
-      secretKey: "sk-test",
-      host: "https://cloud.langfuse.com",
-    });
-    expect(LangfuseCtor).toHaveBeenCalledTimes(1);
-    expect(LangfuseCtor).toHaveBeenCalledWith(
+  const enabledConfig = {
+    enabled: true as const,
+    publicKey: "pk-test",
+    secretKey: "sk-test",
+    host: "https://us.cloud.langfuse.com",
+  };
+
+  it("registers the OTEL SDK and constructs the LangfuseClient with credentials", async () => {
+    await createTracer(enabledConfig);
+    // OTEL setup wired through, in order: span processor → NodeSDK → start → tracer provider hand-off.
+    expect(LangfuseSpanProcessorCtor).toHaveBeenCalledWith(
       expect.objectContaining({
         publicKey: "pk-test",
         secretKey: "sk-test",
-        baseUrl: "https://cloud.langfuse.com",
+        baseUrl: "https://us.cloud.langfuse.com",
+      })
+    );
+    expect(NodeSDKCtor).toHaveBeenCalledTimes(1);
+    expect(sdkNodeStart).toHaveBeenCalledTimes(1);
+    expect(setLangfuseTracerProvider).toHaveBeenCalledTimes(1);
+    expect(LangfuseClientCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicKey: "pk-test",
+        secretKey: "sk-test",
+        baseUrl: "https://us.cloud.langfuse.com",
       })
     );
   });
 
-  it("startTrace calls SDK trace() once and returns an ActiveTrace", async () => {
-    const tracer = await createTracer({
-      enabled: true,
-      publicKey: "pk",
-      secretKey: "sk",
-      host: "https://cloud.langfuse.com",
+  it("startTrace creates a root observation with input + metadata and sets trace-level OTEL attributes", async () => {
+    const tracer = await createTracer(enabledConfig);
+    tracer.startTrace({
+      name: "mcp.request:Read",
+      sessionId: "sess-1",
+      userId: "agent-coder",
+      tags: ["coder"],
+      metadata: { method: "tools/call", requestId: 7, correlationId: "abc" },
+      input: { tool: "Read", requestId: 7, method: "tools/call", correlationId: "abc" },
     });
-    const active = tracer.startTrace({ name: "mcp.request:Read", sessionId: "s1", metadata: { foo: 1 } });
-    expect(langfuseTrace).toHaveBeenCalledTimes(1);
-    expect(langfuseTrace).toHaveBeenCalledWith(
-      expect.objectContaining({ name: "mcp.request:Read", sessionId: "s1" })
+    expect(startObservation).toHaveBeenCalledTimes(1);
+    expect(startObservation).toHaveBeenCalledWith(
+      "mcp.request:Read",
+      expect.objectContaining({
+        input: expect.objectContaining({ tool: "Read", requestId: 7 }),
+        metadata: expect.objectContaining({ method: "tools/call" }),
+      })
     );
-    expect(active).toBeDefined();
-    expect(typeof active.span).toBe("function");
-    expect(typeof active.end).toBe("function");
+    // Trace-level fields go on the root observation's OTEL span via the
+    // LangfuseOtelSpanAttributes registry.
+    expect(otelSpanSetAttribute).toHaveBeenCalledWith("MOCK_TRACE_NAME", "mcp.request:Read");
+    expect(otelSpanSetAttribute).toHaveBeenCalledWith("MOCK_TRACE_SESSION_ID", "sess-1");
+    expect(otelSpanSetAttribute).toHaveBeenCalledWith("MOCK_TRACE_USER_ID", "agent-coder");
+    expect(otelSpanSetAttribute).toHaveBeenCalledWith("MOCK_TRACE_TAGS", JSON.stringify(["coder"]));
+    expect(otelSpanSetAttribute).toHaveBeenCalledWith(
+      "MOCK_TRACE_INPUT",
+      expect.stringContaining('"tool":"Read"')
+    );
   });
 
-  it("ActiveTrace.span calls trace.span with mcp.tool_call and metadata", async () => {
-    const tracer = await createTracer({
-      enabled: true,
-      publicKey: "pk",
-      secretKey: "sk",
-      host: "https://cloud.langfuse.com",
-    });
+  it("ActiveTrace.span creates a child mcp.tool_call observation and ends it immediately", async () => {
+    const tracer = await createTracer(enabledConfig);
     const active = tracer.startTrace({ name: "mcp.request:Read" });
-    active.span({
-      tool: "Read",
-      status: "allowed",
-      durationMs: 12,
-      flags: ["pf1"],
-    });
-    expect(traceSpan).toHaveBeenCalledTimes(1);
-    const arg = traceSpan.mock.calls[0]![0];
-    expect(arg.name).toBe("mcp.tool_call");
-    expect(arg.metadata).toEqual({
-      tool: "Read",
-      status: "allowed",
-      durationMs: 12,
-      flags: ["pf1"],
-    });
+    active.span({ tool: "Read", status: "allowed", durationMs: 12, flags: ["pf1"] });
+    expect(startChildObservation).toHaveBeenCalledTimes(1);
+    expect(startChildObservation).toHaveBeenCalledWith(
+      "mcp.tool_call",
+      expect.objectContaining({
+        metadata: { tool: "Read", status: "allowed", durationMs: 12, flags: ["pf1"] },
+      })
+    );
+    // Child observation closed in the same call — span semantics are point-in-time.
+    expect(childObsEnd).toHaveBeenCalledTimes(1);
   });
 
-  it("ActiveTrace.end updates the trace with outcome metadata", async () => {
-    const tracer = await createTracer({
-      enabled: true,
-      publicKey: "pk",
-      secretKey: "sk",
-      host: "https://cloud.langfuse.com",
-    });
-    const active = tracer.startTrace({ name: "mcp.request:Read" });
-    active.end({ outcome: "allowed" });
-    expect(traceUpdate).toHaveBeenCalledTimes(1);
-    const arg = traceUpdate.mock.calls[0]![0];
-    expect(arg.metadata).toEqual({ outcome: "allowed" });
+  it("ActiveTrace.end updates the root with output + outcome, sets trace tags/output, and ends the root", async () => {
+    const tracer = await createTracer(enabledConfig);
+    const active = tracer.startTrace({ name: "mcp.request:Read", tags: ["coder"] });
+    active.span({ tool: "Read", status: "allowed", durationMs: 12 });
+    active.end({ outcome: "allowed", output: { outcome: "allowed" } });
+    expect(rootObsUpdate).toHaveBeenCalledTimes(1);
+    expect(rootObsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: { outcome: "allowed" },
+        metadata: { outcome: "allowed" },
+      })
+    );
+    expect(rootObsEnd).toHaveBeenCalledTimes(1);
+    // TRACE_TAGS gets set both at start (initial tags) and again at end (with status: + outcome: appended).
+    const tagCalls = otelSpanSetAttribute.mock.calls.filter((c) => c[0] === "MOCK_TRACE_TAGS");
+    expect(tagCalls.length).toBeGreaterThanOrEqual(2);
+    const finalTags = JSON.parse(tagCalls[tagCalls.length - 1]![1] as string);
+    expect(finalTags).toEqual(expect.arrayContaining(["coder", "status:allowed", "outcome:allowed"]));
+    // TRACE_OUTPUT gets set at end.
+    expect(otelSpanSetAttribute).toHaveBeenCalledWith(
+      "MOCK_TRACE_OUTPUT",
+      expect.stringContaining('"outcome":"allowed"')
+    );
   });
 
   it("ActiveTrace.end is idempotent — second call is a no-op at the SDK level", async () => {
-    const tracer = await createTracer({
-      enabled: true,
-      publicKey: "pk",
-      secretKey: "sk",
-      host: "https://cloud.langfuse.com",
-    });
+    const tracer = await createTracer(enabledConfig);
     const active = tracer.startTrace({ name: "mcp.request:Read" });
     active.end({ outcome: "allowed" });
     active.end({ outcome: "error" });
     active.end({ outcome: "blocked" });
-    expect(traceUpdate).toHaveBeenCalledTimes(1);
-    // And span() after end() is also a no-op — the session is closed.
+    expect(rootObsUpdate).toHaveBeenCalledTimes(1);
+    expect(rootObsEnd).toHaveBeenCalledTimes(1);
+    // span() after end() is also a no-op — the session is closed.
     active.span({ tool: "Read", status: "allowed", durationMs: 1 });
-    expect(traceSpan).not.toHaveBeenCalled();
+    expect(startChildObservation).not.toHaveBeenCalled();
   });
 
   it("swallows SDK errors thrown inside ActiveTrace.span", async () => {
-    mockLogger.warn.mockClear();
-    traceSpan.mockImplementationOnce(() => {
+    startChildObservation.mockImplementationOnce(() => {
       throw new Error("boom");
     });
-    const tracer = await createTracer({
-      enabled: true,
-      publicKey: "pk",
-      secretKey: "sk",
-      host: "https://cloud.langfuse.com",
-    });
+    const tracer = await createTracer(enabledConfig);
     const active = tracer.startTrace({ name: "mcp.request:Read" });
-    expect(() =>
-      active.span({ tool: "Read", status: "allowed", durationMs: 1 })
-    ).not.toThrow();
+    expect(() => active.span({ tool: "Read", status: "allowed", durationMs: 1 })).not.toThrow();
     expect(mockLogger.warn).toHaveBeenCalled();
   });
 
   it("swallows SDK errors thrown inside ActiveTrace.end", async () => {
-    mockLogger.warn.mockClear();
-    traceUpdate.mockImplementationOnce(() => {
+    rootObsUpdate.mockImplementationOnce(() => {
       throw new Error("boom");
     });
-    const tracer = await createTracer({
-      enabled: true,
-      publicKey: "pk",
-      secretKey: "sk",
-      host: "https://cloud.langfuse.com",
-    });
+    const tracer = await createTracer(enabledConfig);
     const active = tracer.startTrace({ name: "mcp.request:Read" });
     expect(() => active.end({ outcome: "allowed" })).not.toThrow();
     expect(mockLogger.warn).toHaveBeenCalled();
   });
 
   it("startTrace SDK failure returns the no-op sentinel", async () => {
-    mockLogger.warn.mockClear();
-    langfuseTrace.mockImplementationOnce(() => {
+    startObservation.mockImplementationOnce(() => {
       throw new Error("trace boom");
     });
-    const tracer = await createTracer({
-      enabled: true,
-      publicKey: "pk",
-      secretKey: "sk",
-      host: "https://cloud.langfuse.com",
-    });
+    const tracer = await createTracer(enabledConfig);
     const active = tracer.startTrace({ name: "mcp.request:Read" });
     expect(active).toBe(getNoopActiveTrace());
     expect(mockLogger.warn).toHaveBeenCalled();
   });
 
-  it("flush and shutdown delegate to SDK", async () => {
+  it("flush delegates to LangfuseClient.flush", async () => {
+    const tracer = await createTracer(enabledConfig);
+    await tracer.flush();
+    expect(langfuseClientFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it("shutdown flushes the client, shuts down the OTEL SDK, then shuts down the client", async () => {
+    const order: string[] = [];
+    langfuseClientFlush.mockImplementationOnce(async () => {
+      order.push("client.flush");
+    });
+    sdkNodeShutdown.mockImplementationOnce(async () => {
+      order.push("otel.shutdown");
+    });
+    langfuseClientShutdown.mockImplementationOnce(async () => {
+      order.push("client.shutdown");
+    });
+    const tracer = await createTracer(enabledConfig);
+    await tracer.shutdown();
+    expect(order).toEqual(["client.flush", "otel.shutdown", "client.shutdown"]);
+  });
+
+  it("shutdown swallows errors from any phase — proxy must shut down cleanly even if Langfuse hangs", async () => {
+    sdkNodeShutdown.mockRejectedValueOnce(new Error("otel hung"));
+    const tracer = await createTracer(enabledConfig);
+    await expect(tracer.shutdown()).resolves.toBeUndefined();
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+});
+
+describe("input sanitization invariant (#sensitive-data-hygiene)", () => {
+  it("the wrapper does not inspect or filter input — sanitization is the caller's responsibility", async () => {
+    // This is a contract-level test: the wrapper accepts whatever input is
+    // passed and forwards it to the SDK. It does NOT silently drop fields.
+    // Sensitive-data hygiene (whitelist what's safe to trace) lives at the
+    // call site in src/mcp-proxy/server.ts — this test exists to make that
+    // boundary explicit so a future refactor doesn't push sanitization into
+    // the wrapper (which would create a false sense of security).
     const tracer = await createTracer({
       enabled: true,
       publicKey: "pk",
       secretKey: "sk",
-      host: "https://cloud.langfuse.com",
+      host: "https://us.cloud.langfuse.com",
     });
-    await tracer.flush();
-    await tracer.shutdown();
-    expect(langfuseFlushAsync).toHaveBeenCalledTimes(1);
-    expect(langfuseShutdownAsync).toHaveBeenCalledTimes(1);
+    tracer.startTrace({
+      name: "mcp.request:Read",
+      input: { tool: "Read", requestId: 7, dangerous: "this would not be passed by server.ts" },
+    });
+    expect(startObservation).toHaveBeenCalledWith(
+      "mcp.request:Read",
+      expect.objectContaining({
+        input: expect.objectContaining({ dangerous: "this would not be passed by server.ts" }),
+      })
+    );
   });
 });

--- a/tests/observability/langfuse.test.ts
+++ b/tests/observability/langfuse.test.ts
@@ -66,10 +66,15 @@ vi.mock("@langfuse/otel", () => otelFactory());
 
 const sdkNodeStart = vi.fn();
 const sdkNodeShutdown = vi.fn(async () => {});
+// _tracerProvider is private API on NodeSDK. We read it directly because the
+// public `@opentelemetry/api` `trace.getTracerProvider()` returns a
+// `ProxyTracerProvider` that does not work with `setLangfuseTracerProvider`
+// — see the long comment in src/observability/langfuse.ts for rationale.
+let nodeSDKTracerProvider: unknown = { __sentinel: "tracerProvider" };
 const NodeSDKCtor = vi.fn(function (this: any) {
   this.start = sdkNodeStart;
   this.shutdown = sdkNodeShutdown;
-  this._tracerProvider = { __sentinel: "tracerProvider" };
+  this._tracerProvider = nodeSDKTracerProvider;
 });
 const sdkNodeFactory = vi.fn(() => ({ NodeSDK: NodeSDKCtor }));
 vi.mock("@opentelemetry/sdk-node", () => sdkNodeFactory());
@@ -112,12 +117,14 @@ beforeEach(() => {
   NodeSDKCtor.mockClear();
   sdkNodeStart.mockReset();
   sdkNodeShutdown.mockReset().mockResolvedValue(undefined);
+  nodeSDKTracerProvider = { __sentinel: "tracerProvider" };
   tracingFactory.mockClear();
   clientFactory.mockClear();
   otelFactory.mockClear();
   sdkNodeFactory.mockClear();
   coreFactory.mockClear();
   mockLogger.warn.mockClear();
+  mockLogger.debug.mockClear();
 });
 
 describe("createTracer (no-op mode)", () => {
@@ -171,6 +178,13 @@ describe("createTracer (enabled mode)", () => {
     expect(NodeSDKCtor).toHaveBeenCalledTimes(1);
     expect(sdkNodeStart).toHaveBeenCalledTimes(1);
     expect(setLangfuseTracerProvider).toHaveBeenCalledTimes(1);
+    // We read NodeSDK's private `_tracerProvider` field directly because the
+    // public `@opentelemetry/api` getTracerProvider returns a wrapper that
+    // doesn't work with setLangfuseTracerProvider. See the long comment in
+    // src/observability/langfuse.ts for the empirical rationale (reviewer C2).
+    expect(setLangfuseTracerProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ __sentinel: "tracerProvider" })
+    );
     expect(LangfuseClientCtor).toHaveBeenCalledWith(
       expect.objectContaining({
         publicKey: "pk-test",
@@ -299,6 +313,16 @@ describe("createTracer (enabled mode)", () => {
     expect(langfuseClientFlush).toHaveBeenCalledTimes(1);
   });
 
+  // Reviewer I4: standalone flush() is called from the SIGTERM handler outside
+  // shutdown(); a rejection there must be swallowed and warn-logged so the
+  // process exit isn't blocked by a Langfuse network hiccup.
+  it("flush swallows LangfuseClient.flush rejections (no propagation, warn logged)", async () => {
+    langfuseClientFlush.mockRejectedValueOnce(new Error("network timeout"));
+    const tracer = await createTracer(enabledConfig);
+    await expect(tracer.flush()).resolves.toBeUndefined();
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+
   it("shutdown flushes the client, shuts down the OTEL SDK, then shuts down the client", async () => {
     const order: string[] = [];
     langfuseClientFlush.mockImplementationOnce(async () => {
@@ -320,6 +344,138 @@ describe("createTracer (enabled mode)", () => {
     const tracer = await createTracer(enabledConfig);
     await expect(tracer.shutdown()).resolves.toBeUndefined();
     expect(mockLogger.warn).toHaveBeenCalled();
+  });
+
+  // Reviewer I2: each shutdown phase must time out independently so a single
+  // hanging upstream cannot starve later phases of the global shutdown budget.
+  it("shutdown phases have independent timeouts — a hanging client.flush does not block sdk.shutdown", async () => {
+    let sdkShutdownStarted = false;
+    // client.flush hangs forever (resolved by the per-phase timeout).
+    langfuseClientFlush.mockImplementationOnce(() => new Promise(() => {}));
+    // sdk.shutdown should still run after the flush phase times out.
+    sdkNodeShutdown.mockImplementationOnce(async () => {
+      sdkShutdownStarted = true;
+    });
+    const tracer = await createTracer(enabledConfig);
+    // Wrap with our own outer timeout so a regression hanging both phases
+    // doesn't make this test stall the whole suite.
+    await Promise.race([
+      tracer.shutdown(),
+      new Promise((_, rej) => setTimeout(() => rej(new Error("test outer timeout")), 5000)),
+    ]);
+    expect(sdkShutdownStarted).toBe(true);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
+      expect.stringContaining("client.flush timed out")
+    );
+  });
+
+  // Reviewer I1: silent loss of trace enrichment if the SDK runtime shape
+  // diverges (no otelSpan on the root observation). Warn ONCE per process so
+  // the per-request hot path stays quiet but operators get a signal.
+  it("warns once if rootObs.otelSpan is undefined (SDK shape divergence — silent enrichment loss otherwise)", async () => {
+    startObservation.mockImplementation(() => ({
+      update: rootObsUpdate,
+      end: rootObsEnd,
+      startObservation: startChildObservation,
+      // otelSpan deliberately undefined.
+    }));
+    const tracer = await createTracer(enabledConfig);
+    tracer.startTrace({ name: "mcp.request:A" });
+    tracer.startTrace({ name: "mcp.request:B" });
+    tracer.startTrace({ name: "mcp.request:C" });
+    const matching = mockLogger.warn.mock.calls.filter((c) =>
+      typeof c[0] === "string"
+        ? c[0].includes("rootObs.otelSpan is undefined")
+        : typeof c[1] === "string" && c[1].includes("rootObs.otelSpan is undefined")
+    );
+    expect(matching).toHaveLength(1);
+  });
+
+  // Reviewer C2 (warn fallback): if a future @opentelemetry/sdk-node release
+  // renames or removes the private `_tracerProvider` field, the wrapper must
+  // warn loudly rather than silently lose all traces. The "use the public
+  // OTEL API" half of the C2 advice was infeasible (returns a hollow proxy);
+  // the warn fallback is the practical defense.
+  it("warns when NodeSDK._tracerProvider is undefined (private field absent — silent ingestion failure otherwise)", async () => {
+    nodeSDKTracerProvider = undefined;
+    await createTracer(enabledConfig);
+    const matching = mockLogger.warn.mock.calls.filter((c) =>
+      typeof c[0] === "string" && c[0].includes("NodeSDK._tracerProvider is undefined")
+    );
+    expect(matching).toHaveLength(1);
+  });
+
+  // Reviewer C3: a partial failure inside end() must leave `ended = false`
+  // so a subsequent retry from server.ts's outer catch can attempt cleanup.
+  // OTEL span.end() is idempotent so the retry is safe.
+  it("end leaves ended=false when rootObs.update throws — retry path is intact", async () => {
+    rootObsUpdate.mockImplementationOnce(() => {
+      throw new Error("update boom");
+    });
+    const tracer = await createTracer(enabledConfig);
+    const active = tracer.startTrace({ name: "mcp.request:Read" });
+    active.end({ outcome: "error" });
+    // First call failed inside the try; second call should still attempt the
+    // SDK calls (which now succeed) — proves ended was NOT prematurely flipped.
+    rootObsUpdate.mockImplementationOnce(() => {});
+    active.end({ outcome: "error" });
+    // Two attempts total at update; rootObs.end called once on the successful retry.
+    expect(rootObsUpdate).toHaveBeenCalledTimes(2);
+    expect(rootObsEnd).toHaveBeenCalledTimes(1);
+  });
+
+  // Reviewer S8: end() without an output param must NOT set TRACE_OUTPUT —
+  // the guard prevents the literal string "undefined" from appearing in the UI.
+  it("end without output does not set TRACE_OUTPUT", async () => {
+    const tracer = await createTracer(enabledConfig);
+    const active = tracer.startTrace({ name: "mcp.request:Read" });
+    active.end({ outcome: "allowed" });
+    const outputCalls = otelSpanSetAttribute.mock.calls.filter((c) => c[0] === "MOCK_TRACE_OUTPUT");
+    expect(outputCalls).toHaveLength(0);
+  });
+});
+
+// Reviewer I3: safeSerialize is the safety net for OTEL attribute values.
+// All three branches need coverage so a future refactor that removes the
+// try/catch (or the string-passthrough) is caught by tests.
+describe("safeSerialize behavior (via TRACE_INPUT roundtrip)", () => {
+  const enabledConfig = {
+    enabled: true as const,
+    publicKey: "pk",
+    secretKey: "sk",
+    host: "https://us.cloud.langfuse.com",
+  };
+
+  it("string passthrough — TRACE_INPUT receives the literal string unchanged", async () => {
+    const tracer = await createTracer(enabledConfig);
+    tracer.startTrace({ name: "x", input: "hello world" });
+    expect(otelSpanSetAttribute).toHaveBeenCalledWith("MOCK_TRACE_INPUT", "hello world");
+  });
+
+  it("object input — TRACE_INPUT receives JSON.stringify output", async () => {
+    const tracer = await createTracer(enabledConfig);
+    tracer.startTrace({ name: "x", input: { tool: "Read", requestId: 42 } });
+    expect(otelSpanSetAttribute).toHaveBeenCalledWith(
+      "MOCK_TRACE_INPUT",
+      JSON.stringify({ tool: "Read", requestId: 42 })
+    );
+  });
+
+  it("circular reference — TRACE_INPUT falls back to [unserializable] without throwing", async () => {
+    const circular: Record<string, unknown> = { a: 1 };
+    circular.self = circular;
+    const tracer = await createTracer(enabledConfig);
+    expect(() => tracer.startTrace({ name: "x", input: circular })).not.toThrow();
+    expect(otelSpanSetAttribute).toHaveBeenCalledWith("MOCK_TRACE_INPUT", "[unserializable]");
+  });
+
+  it("BigInt — TRACE_INPUT falls back to [unserializable] without throwing", async () => {
+    const tracer = await createTracer(enabledConfig);
+    expect(() =>
+      tracer.startTrace({ name: "x", input: { count: BigInt("9007199254740993") } })
+    ).not.toThrow();
+    expect(otelSpanSetAttribute).toHaveBeenCalledWith("MOCK_TRACE_INPUT", "[unserializable]");
   });
 });
 

--- a/tests/server-langfuse.test.ts
+++ b/tests/server-langfuse.test.ts
@@ -122,11 +122,24 @@ describe("MCP proxy tracing wire-up", () => {
     expect(startArg.name).toContain("Read");
     expect(startArg.sessionId).toBeUndefined();
     expect(startArg.metadata).toEqual(expect.objectContaining({ requestId: 1, method: "tools/call" }));
+    // Reviewer I5: trace input is a sanitized whitelist set by server.ts.
+    // Asserting the shape here protects against silent regressions where
+    // someone strips the `input` arg or — worse — pushes raw `arguments`
+    // through (which would carry injection text or PII).
+    expect(startArg.input).toEqual(
+      expect.objectContaining({ tool: "Read", requestId: 1, method: "tools/call" })
+    );
+    expect(startArg.input).not.toHaveProperty("arguments");
+    expect(startArg.input).not.toHaveProperty("path");
     expect(tracer.span).toHaveBeenCalledTimes(1);
     expect(tracer.span.mock.calls[0]![0].status).toBe("allowed");
     expect(tracer.span.mock.calls[0]![0].tool).toBe("Read");
     expect(tracer.end).toHaveBeenCalledTimes(1);
     expect(tracer.end.mock.calls[0]![0].outcome).toBe("allowed");
+    // Output snapshot — the UI Output column.
+    expect(tracer.end.mock.calls[0]![0].output).toEqual(
+      expect.objectContaining({ outcome: "allowed" })
+    );
   });
 
   it("traces an allowlist-blocked call as blocked", async () => {
@@ -135,6 +148,13 @@ describe("MCP proxy tracing wire-up", () => {
     expect(tracer.span.mock.calls[0]![0].status).toBe("blocked");
     expect(tracer.end).toHaveBeenCalledTimes(1);
     expect(tracer.end.mock.calls[0]![0].outcome).toBe("blocked");
+    // Reviewer I5: block reason flows through `output.reason`. This is what
+    // surfaces in the Langfuse UI Output column for operators triaging
+    // blocks. Regression here would silently strip the diagnostic context.
+    expect(tracer.end.mock.calls[0]![0].output).toEqual({
+      outcome: "blocked",
+      reason: "allowlist",
+    });
   });
 
   it("traces a sanitizer-flagged call as flagged with concrete pattern strings (#I13)", async () => {
@@ -151,6 +171,17 @@ describe("MCP proxy tracing wire-up", () => {
     expect(meta.flags).toContain("ignore_instructions");
     expect(tracer.end).toHaveBeenCalledTimes(1);
     expect(tracer.end.mock.calls[0]![0].outcome).toBe("flagged");
+    // Reviewer I5: flagged outputs include the patterns array so the UI
+    // surfaces *which* injection rule fired, without re-leaking raw matched
+    // content (the patterns are pattern names, not the matched substrings).
+    const out = tracer.end.mock.calls[0]![0].output as Record<string, unknown>;
+    expect(out).toEqual(
+      expect.objectContaining({
+        outcome: "flagged",
+        phase: "request",
+        patterns: expect.arrayContaining(["ignore_instructions"]),
+      })
+    );
   });
 
   it("traces a path-guard block as blocked (#I7)", async () => {


### PR DESCRIPTION
## Summary

- Migrates from `langfuse@^3.38.20` (single package, imperative `client.trace()/.span()/.update()`) to the v5 package layout: `@langfuse/tracing`, `@langfuse/client`, `@langfuse/otel`, plus `@opentelemetry/sdk-node` for the OTEL runtime v5 requires.
- Rewrites `src/observability/langfuse.ts` internally while preserving the public `Tracer`/`ActiveTrace` contract — `src/mcp-proxy/server.ts` and the wrapper-level tests at `tests/server-langfuse.test.ts` are unaffected.
- Populates trace `input` (sanitized whitelist), `output` (terminal outcome + context), and `tags` (`status:*`, `outcome:*`) so the Langfuse UI surfaces useful data instead of empty Input/Output columns. The Langfuse skill flagged this as a baseline-instrumentation gap during the audit that motivated this PR.
- Updates `docs/observability.md` to reflect the v5 architecture and the new trace shape.

## Why now

agentic-press has been on v3 since Phase 1 shipped (PR #30). v4 was a major OTEL-based rewrite; v5 added the observation-centric data model. Continuing on v3 while building toward Phase 2 multi-agent orchestration is the wrong default — Phase 2 wires `sessionId`/`userId` into traces, which v5 expresses natively. The `StartTraceParams` interface in this PR adds those reserved fields (currently undefined) so server.ts will not need a structural change when Phase 2 wires them up.

## Architectural choices

- **Wrapper boundary preserved.** Server.ts continues using the `Tracer.startTrace() → span() → end()` interface exactly as before. The 11 `safeSpan`/`safeEnd` call sites pass new `output` payloads but the call shape is unchanged.
- **OTEL setup folded into the wrapper, not src/index.ts.** Keeps the single SDK boundary intact; consumers don't need to know about OTEL.
- **`startObservation` (non-callback variant) over `propagateAttributes(callback)`.** v5's recommended callback pattern would require restructuring server.ts's pipeline (11 sites with short-circuit branches) around nested callbacks. The non-callback API preserves our positional/synchronous interface; trace-level OTEL attributes (`session.id`, `user.id`, tags, input, output) are set directly on the root observation's underlying OTEL span via `LangfuseOtelSpanAttributes`.
- **Span semantics simplified to point-in-time.** v3 held one trace + one span open until end. v5 wrapper creates a child observation `mcp.tool_call` and ends it immediately at the same `span()` call site. The span represents a stage decision, not a long-running operation. Trace tree shape (root + one child) matches v3 from an operator's perspective.
- **Three-stage shutdown isolation.** Each of `client.flush`, `otel.sdk.shutdown`, `client.shutdown` is wrapped in its own try/catch. A hang or error in one phase cannot block the others — preserves the "observability never breaks request path / shutdown" invariant.
- **Sensitive-data hygiene.** Trace `input` is a whitelist of `{tool, requestId, method, correlationId}` set by server.ts — never the raw `arguments` payload (could carry injection text or PII per the sanitizer's threat model). The wrapper itself does not inspect or filter input; sanitization is the caller's responsibility, and there's a regression test asserting that boundary.

## Safety properties preserved (all four from v3)

1. Frozen `NOOP_ACTIVE_TRACE` sentinel — disabled path allocates zero per request.
2. Dynamic-import isolation — none of `@langfuse/*`, `@opentelemetry/sdk-node`, or `@langfuse/core` load when `LANGFUSE_*` keys are absent. Asserted by `tests/observability/langfuse-noop-isolation.test.ts`.
3. Try/catch around every SDK call (start, span, end, flush, shutdown, OTEL sdk shutdown). Errors logged at `warn`, never rethrown.
4. Idempotent `end()` — second call is a no-op at the SDK level.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 572 passed (was 569; +3 from tighter shutdown ordering tests in the v5 wrapper). All 36 test files green.
- [x] `npm run build` — clean
- [x] Live end-to-end against US Langfuse Cloud — 4 traces fired with allowed/blocked-allowlist/flagged-injection/blocked-path-traversal pipeline outcomes; all 4 land with `input`, `output`, and `tags` populated as designed; verified via `/api/public/traces`.
- [x] No SDK warnings on startup; no warnings during 4-call run.
- [x] Graceful SIGTERM completes in ~600ms with traces flushed.
- [ ] **Reviewer to verify:** `./scripts/sandbox-run.sh` still passes all 14 assertions (script doesn't enable tracing, so likely passes — but worth confirming under v5 once before merge).

## Out of scope

- Wiring `userId` / `sessionId` to actual agent identity. Phase 2 work — the wrapper API gains the params now (currently undefined), so server.ts will not need a structural change when Phase 2 wires them up.
- LLM-side observability. The MCP proxy doesn't see LLM traffic. A new "LLM proxy" component is the right place; tracked as Tier 2.5 in the orchestration kickoff at `~/Obsidian/claude-workspace/Plans/agentic-press-orchestration.md`.
- Self-hosted Langfuse considerations (we use Cloud; v5 self-host caveats around `api.observations` v2 endpoints don't apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)