### PR TITLE
chore: gitignore .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 .env
 .env.*
 !.env.example
+.envrc
 *.log
 coverage/
 .DS_Store


### PR DESCRIPTION
## Summary
- Adds `.envrc` to `.gitignore` so direnv-managed local env files cannot be accidentally committed.

## Why
The repo already gitignores `.env` and `.env.*`. `.envrc` is direnv's analog and frequently holds project-scoped credentials (Keychain references, OAuth tokens, local-only service endpoints). Without this entry, a developer setting up direnv per the patterns we used during the PR #49 telemetry-validation session could trip into staging the file by mistake.

This is a one-line, zero-risk change.

## Test plan
- [x] Visual review of `.gitignore` diff
- [x] No code, no behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)