### PR TITLE
feat: identity headers on /mcp request envelope (Tier 1.1)

### DIFF
--- a/src/mcp-proxy/server.ts
+++ b/src/mcp-proxy/server.ts
@@ -21,6 +21,54 @@ import { createNoopRecorder, type MetricsRecorder, type BlockReason } from "../o
 
 const log = childLogger("mcp-proxy");
 
+/**
+ * Identity headers (Phase 2 Tier 1.1).
+ *
+ * The proxy accepts two optional headers on /mcp that identify the calling
+ * agent so observability surfaces (Langfuse traces; later: audit, metrics,
+ * dashboard events) can demultiplex per-agent. Both are operator-controlled
+ * — the dispatch CLI / Mission Control connector sets them when launching a
+ * sandbox. Sandboxes never set them themselves.
+ *
+ *   X-Agent-Session-Id  — opaque session label, max 128 chars, [A-Za-z0-9._-]+
+ *   X-Agent-Type        — short agent role (e.g. "reviewer"), max 32 chars
+ *
+ * Charset is restricted so the values are safe to use as Prometheus label
+ * values, OTEL span attribute keys, and audit-log fields without further
+ * escaping. The bound is also a cardinality defence: operator-controlled but
+ * still bounded so a misbehaving caller cannot blow up the Prometheus
+ * registry. Both headers are OPTIONAL; missing → undefined → request behaves
+ * exactly as in Phase 1.
+ *
+ * Malformed values warn-log and fall through to undefined. Identity-header
+ * parsing must NEVER reject a request (anchor #5: observability/identity
+ * issues never break the request path). A misconfigured caller still gets
+ * its tool call processed; the operator sees the warning and fixes the
+ * caller.
+ */
+const IDENTITY_VALUE_PATTERN = /^[A-Za-z0-9._-]+$/;
+const SESSION_ID_MAX_LEN = 128;
+const AGENT_TYPE_MAX_LEN = 32;
+
+type WarnLogger = { warn: (obj: Record<string, unknown>, msg: string) => void };
+
+function parseIdentityHeader(
+  raw: string | undefined,
+  headerName: string,
+  maxLen: number,
+  reqLog: WarnLogger
+): string | undefined {
+  if (raw === undefined) return undefined;
+  if (raw.length === 0 || raw.length > maxLen || !IDENTITY_VALUE_PATTERN.test(raw)) {
+    reqLog.warn(
+      { header: headerName, length: raw.length, maxLen },
+      "identity header malformed — ignored, request will be processed without identity"
+    );
+    return undefined;
+  }
+  return raw;
+}
+
 export interface ProxyServerConfig {
   readonly port: number;
   readonly allowedTools: readonly string[];
@@ -256,10 +304,33 @@ export function createProxyServer(config: ProxyServerConfig): Express {
       const tool = toolName; // Narrowed alias for use inside async callbacks
       const toolArgs = (params.arguments ?? {}) as Record<string, unknown>;
 
-      // Start the trace once we know which tool was requested. Note: sessionId
-      // is intentionally omitted — there is no real session concept yet, and
-      // per-request JSON-RPC ids would defeat Langfuse's session grouping. The
-      // request id travels in metadata so it is still searchable.
+      // Phase 2 Tier 1.1: extract identity headers. Both are optional; missing
+      // → undefined preserves Phase 1 behaviour. Malformed → warn-log + undefined
+      // (must never 400-reject, anchor #5).
+      const sessionId = parseIdentityHeader(
+        req.header("x-agent-session-id"),
+        "X-Agent-Session-Id",
+        SESSION_ID_MAX_LEN,
+        reqLog
+      );
+      const agentType = parseIdentityHeader(
+        req.header("x-agent-type"),
+        "X-Agent-Type",
+        AGENT_TYPE_MAX_LEN,
+        reqLog
+      );
+
+      // Initial tags include agentType when present so operators can filter
+      // Langfuse traces by agent role. The wrapper appends status:<status>
+      // and outcome:<outcome> later — see src/observability/langfuse.ts.
+      const initialTags = agentType ? [`agentType:${agentType}`] : undefined;
+
+      // Start the trace once we know which tool was requested. sessionId and
+      // userId propagate to OTEL session.id / user.id so the Langfuse UI
+      // groups all of an agent's traces in the Sessions / Users views.
+      // userId is the agent type (e.g. "reviewer"), giving us per-role
+      // filtering and cost attribution in the single-user model — until a
+      // multi-user surface ever shows up, agent role is the closest analogue.
       //
       // Defensive try/catch even though ActiveTrace.span/end isolate errors:
       // a future Tracer impl could throw from startTrace itself. If it does,
@@ -271,10 +342,19 @@ export function createProxyServer(config: ProxyServerConfig): Express {
           metadata: { method, requestId, correlationId },
           // Trace-level input snapshot. Whitelist of safe fields only — never
           // include raw `arguments` (could carry injection text or PII per the
-          // sanitizer's threat model). Operators see this as the Input column
-          // in the Langfuse UI and use it to identify the request without
-          // exposing the payload that the sanitizer is meant to gate.
-          input: { tool, requestId, method, correlationId },
+          // sanitizer's threat model). Identity headers are operator-set,
+          // charset-validated above, and safe to surface in the UI Input column.
+          input: {
+            tool,
+            requestId,
+            method,
+            correlationId,
+            ...(sessionId ? { sessionId } : {}),
+            ...(agentType ? { agentType } : {}),
+          },
+          ...(sessionId ? { sessionId } : {}),
+          ...(agentType ? { userId: agentType } : {}),
+          ...(initialTags ? { tags: initialTags } : {}),
         });
       } catch (err) {
         reqLog.warn({ err }, "startTrace failed");

--- a/src/mcp-proxy/server.ts
+++ b/src/mcp-proxy/server.ts
@@ -22,7 +22,7 @@ import { createNoopRecorder, type MetricsRecorder, type BlockReason } from "../o
 const log = childLogger("mcp-proxy");
 
 /**
- * Identity headers (Phase 2 Tier 1.1).
+ * Identity headers (Phase 2 Tier 1.1, see issue #51).
  *
  * The proxy accepts two optional headers on /mcp that identify the calling
  * agent so observability surfaces (Langfuse traces; later: audit, metrics,
@@ -34,21 +34,32 @@ const log = childLogger("mcp-proxy");
  *   X-Agent-Type        — short agent role (e.g. "reviewer"), max 32 chars
  *
  * Charset is restricted so the values are safe to use as Prometheus label
- * values, OTEL span attribute keys, and audit-log fields without further
+ * values, OTEL span attribute values, and audit-log fields without further
  * escaping. The bound is also a cardinality defence: operator-controlled but
  * still bounded so a misbehaving caller cannot blow up the Prometheus
  * registry. Both headers are OPTIONAL; missing → undefined → request behaves
  * exactly as in Phase 1.
  *
- * Malformed values warn-log and fall through to undefined. Identity-header
- * parsing must NEVER reject a request (anchor #5: observability/identity
- * issues never break the request path). A misconfigured caller still gets
- * its tool call processed; the operator sees the warning and fixes the
- * caller.
+ * Duplicate headers (e.g. from a reverse proxy that does not deduplicate)
+ * arrive as a single comma-joined string from `req.header()`. The comma
+ * fails the charset regex, so the value degrades to undefined — request
+ * still processes. Tested in `tests/server-identity-headers.test.ts`.
+ *
+ * Malformed values warn-log (with a bounded value sample for operator
+ * diagnostics) and fall through to undefined. Identity-header parsing must
+ * NEVER reject a request (#C5: observability/identity issues never break
+ * the request path). A misconfigured caller still gets its tool call
+ * processed; the operator sees the warning and fixes the caller.
  */
 const IDENTITY_VALUE_PATTERN = /^[A-Za-z0-9._-]+$/;
 const SESSION_ID_MAX_LEN = 128;
 const AGENT_TYPE_MAX_LEN = 32;
+/**
+ * How many characters of a malformed value to include in the warn log so
+ * operators can diagnose the misconfiguration. Bounded to keep the log line
+ * size predictable even when an attacker submits a megabyte-long header.
+ */
+const IDENTITY_LOG_SAMPLE_LEN = 32;
 
 type WarnLogger = { warn: (obj: Record<string, unknown>, msg: string) => void };
 
@@ -60,8 +71,12 @@ function parseIdentityHeader(
 ): string | undefined {
   if (raw === undefined) return undefined;
   if (raw.length === 0 || raw.length > maxLen || !IDENTITY_VALUE_PATTERN.test(raw)) {
+    const valueSample =
+      raw.length > IDENTITY_LOG_SAMPLE_LEN
+        ? raw.slice(0, IDENTITY_LOG_SAMPLE_LEN) + "…"
+        : raw;
     reqLog.warn(
-      { header: headerName, length: raw.length, maxLen },
+      { header: headerName, length: raw.length, maxLen, valueSample },
       "identity header malformed — ignored, request will be processed without identity"
     );
     return undefined;
@@ -306,7 +321,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
 
       // Phase 2 Tier 1.1: extract identity headers. Both are optional; missing
       // → undefined preserves Phase 1 behaviour. Malformed → warn-log + undefined
-      // (must never 400-reject, anchor #5).
+      // (must never 400-reject, #C5).
       const sessionId = parseIdentityHeader(
         req.header("x-agent-session-id"),
         "X-Agent-Session-Id",
@@ -326,11 +341,13 @@ export function createProxyServer(config: ProxyServerConfig): Express {
       const initialTags = agentType ? [`agentType:${agentType}`] : undefined;
 
       // Start the trace once we know which tool was requested. sessionId and
-      // userId propagate to OTEL session.id / user.id so the Langfuse UI
-      // groups all of an agent's traces in the Sessions / Users views.
-      // userId is the agent type (e.g. "reviewer"), giving us per-role
-      // filtering and cost attribution in the single-user model — until a
-      // multi-user surface ever shows up, agent role is the closest analogue.
+      // userId are passed through to Langfuse's trace-level attributes
+      // (TRACE_SESSION_ID / TRACE_USER_ID via @langfuse/core) so the
+      // Langfuse UI groups traces in the Sessions and Users views — these
+      // are Langfuse-specific keys, not OTEL semantic conventions. userId
+      // is the agent type (e.g. "reviewer"), giving us per-role filtering
+      // and cost attribution in the single-user model — until a multi-user
+      // surface ever shows up, agent role is the closest analogue.
       //
       // Defensive try/catch even though ActiveTrace.span/end isolate errors:
       // a future Tracer impl could throw from startTrace itself. If it does,

--- a/tests/server-identity-headers.test.ts
+++ b/tests/server-identity-headers.test.ts
@@ -174,9 +174,10 @@ describe("MCP proxy identity headers (X-Agent-Session-Id, X-Agent-Type)", () => 
     await mcpCall(url, 7, "Read", {}, { "X-Agent-Type": tooLong });
     const arg = tracer.startTrace.mock.calls[0]![0];
     expect(arg.userId).toBeUndefined();
-    if (arg.tags) {
-      expect(arg.tags).not.toEqual(expect.arrayContaining([expect.stringMatching(/^agentType:/)]));
-    }
+    // Reviewer fix #6: assert the absence directly. The previous `if (arg.tags)`
+    // guard short-circuited the assertion to a no-op because tags is always
+    // undefined when agentType is rejected.
+    expect(arg.tags).toBeUndefined();
     expect(mockLogger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ header: "X-Agent-Type" }),
       expect.stringMatching(/identity header/i)
@@ -213,5 +214,50 @@ describe("MCP proxy identity headers (X-Agent-Session-Id, X-Agent-Type)", () => 
     expect(arg.sessionId).toBe(sessionAtLimit);
     expect(arg.userId).toBe(typeAtLimit);
     expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it("warn-logs and ignores duplicated identity headers (joined value fails charset)", async () => {
+    // Reviewer fix #5: lock in the duplicate-header behaviour. When a reverse
+    // proxy or buggy client sends the same header twice, Node delivers a
+    // single comma-joined string to `req.header()`. The comma fails our
+    // charset regex, so the value degrades to undefined and the request
+    // still processes. This is "accidentally correct" today; the test makes
+    // the behaviour intentional.
+    const headers = new Headers({ "Content-Type": "application/json" });
+    headers.append("X-Agent-Session-Id", "first-value");
+    headers.append("X-Agent-Session-Id", "second-value");
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 11,
+        method: "tools/call",
+        params: { name: "Read", arguments: {} },
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(tracer.startTrace).toHaveBeenCalledTimes(1);
+    expect(tracer.startTrace.mock.calls[0]![0].sessionId).toBeUndefined();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ header: "X-Agent-Session-Id" }),
+      expect.stringMatching(/identity header/i)
+    );
+  });
+
+  it("warn log includes a bounded value sample for operator diagnostics", async () => {
+    // Reviewer fix #4: warn log carries a truncated value sample so operators
+    // can identify which dispatch CLI / connector is misconfigured without
+    // having to reproduce the request. Truncated to IDENTITY_LOG_SAMPLE_LEN
+    // (32) so a megabyte-long header doesn't blow up the log line size.
+    const tooLong = "a".repeat(200);
+    await mcpCall(url, 12, "Read", {}, { "X-Agent-Session-Id": tooLong });
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        header: "X-Agent-Session-Id",
+        valueSample: expect.stringMatching(/^a{32}…$/),
+      }),
+      expect.stringMatching(/identity header/i)
+    );
   });
 });

--- a/tests/server-identity-headers.test.ts
+++ b/tests/server-identity-headers.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+
+const { mockLogger } = vi.hoisted(() => {
+  const mockLogger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn(),
+  };
+  mockLogger.child.mockReturnValue(mockLogger);
+  return { mockLogger };
+});
+vi.mock("../src/logger.js", () => ({
+  default: mockLogger, childLogger: vi.fn(() => mockLogger),
+}));
+
+import { createProxyServer, type ProxyServerConfig } from "../src/mcp-proxy/server.js";
+import type { Tracer, ActiveTrace } from "../src/observability/langfuse.js";
+import type { StdioBridge } from "../src/mcp-proxy/stdio-bridge.js";
+
+interface SpyTracer extends Tracer {
+  startTrace: ReturnType<typeof vi.fn>;
+  span: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+  flush: ReturnType<typeof vi.fn>;
+  shutdown: ReturnType<typeof vi.fn>;
+}
+
+function makeSpyTracer(): SpyTracer {
+  const span = vi.fn();
+  const end = vi.fn();
+  const active = { span, end } as unknown as ActiveTrace;
+  const startTrace = vi.fn(() => active);
+  return {
+    startTrace, span, end,
+    flush: vi.fn(async () => {}),
+    shutdown: vi.fn(async () => {}),
+  };
+}
+
+function makeBridge(): StdioBridge {
+  return {
+    call: vi.fn(async () => ({ content: "ok" })),
+    shutdown: vi.fn(async () => {}),
+  } as unknown as StdioBridge;
+}
+
+function makeConfig(overrides: Partial<ProxyServerConfig> = {}): ProxyServerConfig {
+  return {
+    port: 0,
+    allowedTools: ["Read"],
+    logLevel: "error",
+    ...overrides,
+  };
+}
+
+async function startServer(config: ProxyServerConfig): Promise<{ server: Server; url: string }> {
+  const app = createProxyServer(config);
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const addr = server.address() as AddressInfo;
+  return { server, url: `http://127.0.0.1:${addr.port}/mcp` };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function mcpCall(
+  url: string,
+  id: number,
+  toolName: string,
+  args: Record<string, unknown> = {},
+  headers: Record<string, string> = {}
+) {
+  return fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: { name: toolName, arguments: args },
+    }),
+  });
+}
+
+describe("MCP proxy identity headers (X-Agent-Session-Id, X-Agent-Type)", () => {
+  let server: Server;
+  let url: string;
+  let tracer: SpyTracer;
+
+  beforeEach(async () => {
+    tracer = makeSpyTracer();
+    const started = await startServer(makeConfig({
+      bridge: makeBridge(),
+      serverRoutes: { Read: "fs" },
+      tracer,
+    }));
+    server = started.server;
+    url = started.url;
+    mockLogger.warn.mockClear();
+  });
+
+  afterEach(async () => {
+    await closeServer(server);
+  });
+
+  it("pipes X-Agent-Session-Id to startTrace as sessionId", async () => {
+    await mcpCall(url, 1, "Read", { path: "./pkg.json" }, { "X-Agent-Session-Id": "review-001" });
+    expect(tracer.startTrace).toHaveBeenCalledTimes(1);
+    expect(tracer.startTrace.mock.calls[0]![0].sessionId).toBe("review-001");
+  });
+
+  it("pipes X-Agent-Type to startTrace as userId AND tags it as agentType:<value>", async () => {
+    await mcpCall(url, 2, "Read", { path: "./pkg.json" }, { "X-Agent-Type": "reviewer" });
+    expect(tracer.startTrace).toHaveBeenCalledTimes(1);
+    const arg = tracer.startTrace.mock.calls[0]![0];
+    expect(arg.userId).toBe("reviewer");
+    expect(arg.tags).toEqual(expect.arrayContaining(["agentType:reviewer"]));
+  });
+
+  it("includes both identity values in startTrace input for trace UI visibility", async () => {
+    await mcpCall(url, 3, "Read", {}, {
+      "X-Agent-Session-Id": "sess-3",
+      "X-Agent-Type": "coder",
+    });
+    const arg = tracer.startTrace.mock.calls[0]![0];
+    expect(arg.input).toEqual(expect.objectContaining({
+      sessionId: "sess-3",
+      agentType: "coder",
+    }));
+    // The whitelist guarantee from sanitizer threat model still holds — raw
+    // arguments must NEVER appear in the trace input. Regression backstop.
+    expect(arg.input).not.toHaveProperty("arguments");
+  });
+
+  it("preserves today's behaviour when no identity headers are sent", async () => {
+    await mcpCall(url, 4, "Read", { path: "./pkg.json" });
+    const arg = tracer.startTrace.mock.calls[0]![0];
+    expect(arg.sessionId).toBeUndefined();
+    expect(arg.userId).toBeUndefined();
+    expect(arg.tags).toBeUndefined();
+    // Headerless input shape unchanged from Phase 1: no sessionId/agentType keys.
+    expect(arg.input).toEqual({
+      tool: "Read",
+      requestId: 4,
+      method: "tools/call",
+      correlationId: expect.any(String),
+    });
+  });
+
+  it("warn-logs and ignores X-Agent-Session-Id longer than 128 chars", async () => {
+    const tooLong = "a".repeat(129);
+    await mcpCall(url, 5, "Read", {}, { "X-Agent-Session-Id": tooLong });
+    expect(tracer.startTrace.mock.calls[0]![0].sessionId).toBeUndefined();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ header: "X-Agent-Session-Id" }),
+      expect.stringMatching(/identity header/i)
+    );
+  });
+
+  it("warn-logs and ignores X-Agent-Session-Id with disallowed characters", async () => {
+    await mcpCall(url, 6, "Read", {}, { "X-Agent-Session-Id": "bad value with spaces!" });
+    expect(tracer.startTrace.mock.calls[0]![0].sessionId).toBeUndefined();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ header: "X-Agent-Session-Id" }),
+      expect.stringMatching(/identity header/i)
+    );
+  });
+
+  it("warn-logs and ignores X-Agent-Type longer than 32 chars (no agentType tag emitted)", async () => {
+    const tooLong = "a".repeat(33);
+    await mcpCall(url, 7, "Read", {}, { "X-Agent-Type": tooLong });
+    const arg = tracer.startTrace.mock.calls[0]![0];
+    expect(arg.userId).toBeUndefined();
+    if (arg.tags) {
+      expect(arg.tags).not.toEqual(expect.arrayContaining([expect.stringMatching(/^agentType:/)]));
+    }
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ header: "X-Agent-Type" }),
+      expect.stringMatching(/identity header/i)
+    );
+  });
+
+  it("warn-logs and ignores X-Agent-Type with disallowed characters", async () => {
+    await mcpCall(url, 8, "Read", {}, { "X-Agent-Type": "bad type!" });
+    const arg = tracer.startTrace.mock.calls[0]![0];
+    expect(arg.userId).toBeUndefined();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ header: "X-Agent-Type" }),
+      expect.stringMatching(/identity header/i)
+    );
+  });
+
+  it("malformed identity headers do NOT 400 — request still processes (anchor #5)", async () => {
+    const res = await mcpCall(url, 9, "Read", { path: "./pkg.json" }, {
+      "X-Agent-Session-Id": "a".repeat(200),
+      "X-Agent-Type": "x!?",
+    });
+    expect(res.status).toBe(200);
+    expect(tracer.startTrace).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts boundary-length identity values (128 / 32 chars)", async () => {
+    const sessionAtLimit = "a".repeat(128);
+    const typeAtLimit = "a".repeat(32);
+    await mcpCall(url, 10, "Read", {}, {
+      "X-Agent-Session-Id": sessionAtLimit,
+      "X-Agent-Type": typeAtLimit,
+    });
+    const arg = tracer.startTrace.mock.calls[0]![0];
+    expect(arg.sessionId).toBe(sessionAtLimit);
+    expect(arg.userId).toBe(typeAtLimit);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
First Phase 2 increment per `~/Obsidian/claude-workspace/Plans/agentic-press-orchestration-detailed.md` §3.1. Substrate for multi-agent observability demux — wires the two reserved fields on `StartTraceParams` (`sessionId`, `userId`, `tags`) to operator-set request headers so Langfuse can group traces per session and per agent role.

## Summary

- The `/mcp` request handler now extracts `X-Agent-Session-Id` and `X-Agent-Type` (both optional) from request headers and passes them to `tracer.startTrace` as `sessionId`, `userId`, and an initial tag list.
- Validation: charset `[A-Za-z0-9._-]+`, max 128 chars (session id) / 32 chars (agent type). Bounds chosen for Prometheus-label safety and cardinality defence.
- Identity issues never 400-reject (anchor #5). Malformed values warn-log and fall through to undefined; the request still processes normally.
- Backward compat preserved exactly — missing headers behave identically to Phase 1.

## Out of scope (deferred to later increments)

- Threading sessionId/agentType through `AuditEntry`, `ActivityEvent`, MC adapter, or Prometheus labels — Tier 1.2.
- Per-session allowlist registry — Tier 1.3.
- Multi-agent dispatch CLI / acceptance test — Tier 1.4 / 1.5.
- Mission Control connection adapter — Tier 2.A.

## Test plan

- [x] `npm test` — all tests pass (582 → 592, +10 new)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] New tests in `tests/server-identity-headers.test.ts` cover:
  - sessionId pipes through to `startTrace`
  - agentType pipes through as both `userId` and tag `agentType:<value>`
  - both values appear in trace `input` for UI visibility (with no-arguments backstop)
  - missing-header backward compat (input shape and undefined fields exactly as today)
  - malformed values (length + charset, both headers) warn-log and fall through to undefined
  - malformed values do not cause a 400 — request still processes (anchor #5)
  - boundary-length values (128 / 32 chars) are accepted with no warn
- [ ] Live curl with identity headers lands a Langfuse trace with `session.id` / `user.id` populated (manual smoke after merge, optional)

Closes #51