### PR TITLE
feat: thread sessionId/agentType through audit + events + metrics (Tier 1.2)

### DIFF
--- a/src/dashboard/adapter.ts
+++ b/src/dashboard/adapter.ts
@@ -20,7 +20,22 @@ export interface ActivityEvent {
   readonly durationMs?: number;
   readonly flags?: readonly string[];
   readonly errorMessage?: string;
+  /**
+   * Phase 2 Tier 1.2 (#53): per-agent identity. Both optional. When set,
+   * `agentType` becomes MC's `agent_name` so the Tasks / Activity panels can
+   * demultiplex per agent role; `sessionId` is included in the event payload
+   * so MC can group activity by session.
+   */
+  readonly sessionId?: string;
+  readonly agentType?: string;
 }
+
+/**
+ * Default agent name MC sees when an event has no agentType. Kept here as a
+ * single export so the upcoming MC connection adapter (Tier 2.A) can register
+ * with the same name and the kanban board attribution stays consistent.
+ */
+export const DEFAULT_AGENT_NAME = "agentic-press-proxy";
 
 export interface DashboardAdapter {
   registerSession(sandboxName: SandboxId, taskDescription?: string): Promise<DashboardSession>;
@@ -127,12 +142,21 @@ export function createMissionControlAdapter(
       // MC's /api/hermes/events is the write endpoint for agent lifecycle
       // events — it persists to the activities table and broadcasts via SSE.
       // /api/activities is read-only (405 on POST).
+      //
+      // Tier 1.2 identity propagation:
+      //   - agent_name uses event.agentType when set so MC's panels show
+      //     per-role activity (e.g. all "reviewer" activity grouped). Falls
+      //     back to DEFAULT_AGENT_NAME when no agent type was passed —
+      //     preserves Phase 1 behaviour for headerless callers.
+      //   - data.session_id carries event.sessionId when set so MC can group
+      //     events by task/session in its Activity views. Omitted entirely
+      //     when absent (no `session_id: undefined` noise).
       await safeFetch(`${config.url}/api/hermes/events`, {
         method: "POST",
         headers: headers(),
         body: JSON.stringify({
           event: `tool:${event.type}`,
-          agent_name: "agentic-press-proxy",
+          agent_name: event.agentType ?? DEFAULT_AGENT_NAME,
           source: "mcp-proxy",
           timestamp: event.timestamp,
           data: {
@@ -141,6 +165,7 @@ export function createMissionControlAdapter(
             durationMs: event.durationMs,
             flags: event.flags,
             errorMessage: event.errorMessage,
+            ...(event.sessionId !== undefined ? { session_id: event.sessionId } : {}),
           },
         }),
       });

--- a/src/dashboard/adapter.ts
+++ b/src/dashboard/adapter.ts
@@ -21,19 +21,19 @@ export interface ActivityEvent {
   readonly flags?: readonly string[];
   readonly errorMessage?: string;
   /**
-   * Phase 2 Tier 1.2 (#53): per-agent identity. Both optional. When set,
-   * `agentType` becomes MC's `agent_name` so the Tasks / Activity panels can
-   * demultiplex per agent role; `sessionId` is included in the event payload
-   * so MC can group activity by session.
+   * Per-agent identity propagated from the proxy's request envelope (#53).
+   * `sessionId` identifies a specific run/task; `agentType` identifies the
+   * role (e.g. "reviewer", "coder"). Both optional — Phase 1 single-agent
+   * deployments emit events with neither.
    */
   readonly sessionId?: string;
   readonly agentType?: string;
 }
 
 /**
- * Default agent name MC sees when an event has no agentType. Kept here as a
- * single export so the upcoming MC connection adapter (Tier 2.A) can register
- * with the same name and the kanban board attribution stays consistent.
+ * Agent name attributed to events with no `agentType`. Exported so the
+ * planned MC connection adapter can register under the same name and the
+ * board attribution stays consistent.
  */
 export const DEFAULT_AGENT_NAME = "agentic-press-proxy";
 
@@ -142,15 +142,6 @@ export function createMissionControlAdapter(
       // MC's /api/hermes/events is the write endpoint for agent lifecycle
       // events — it persists to the activities table and broadcasts via SSE.
       // /api/activities is read-only (405 on POST).
-      //
-      // Tier 1.2 identity propagation:
-      //   - agent_name uses event.agentType when set so MC's panels show
-      //     per-role activity (e.g. all "reviewer" activity grouped). Falls
-      //     back to DEFAULT_AGENT_NAME when no agent type was passed —
-      //     preserves Phase 1 behaviour for headerless callers.
-      //   - data.session_id carries event.sessionId when set so MC can group
-      //     events by task/session in its Activity views. Omitted entirely
-      //     when absent (no `session_id: undefined` noise).
       await safeFetch(`${config.url}/api/hermes/events`, {
         method: "POST",
         headers: headers(),

--- a/src/dashboard/event-bridge.ts
+++ b/src/dashboard/event-bridge.ts
@@ -64,6 +64,11 @@ export function createEventBridge(adapter: DashboardAdapter): EventBridge {
         ? { flags: entry.flags.map((f) => f.pattern) }
         : {}),
       ...(entry.errorMessage ? { errorMessage: entry.errorMessage } : {}),
+      // Phase 2 Tier 1.2 (#53): identity propagation. Optional in both
+      // directions — when AuditEntry has neither, ActivityEvent omits both,
+      // so the MC POST body keeps its Phase 1 shape exactly.
+      ...(entry.sessionId !== undefined ? { sessionId: entry.sessionId } : {}),
+      ...(entry.agentType !== undefined ? { agentType: entry.agentType } : {}),
     };
 
     const p = adapter.pushActivity(event).catch((err) => {

--- a/src/mcp-proxy/logger.ts
+++ b/src/mcp-proxy/logger.ts
@@ -24,6 +24,16 @@ export interface AuditEntry {
    * Error object or stack trace).
    */
   readonly errorMessage?: string;
+  /**
+   * Phase 2 Tier 1.2 (#53): per-agent identity propagated from
+   * X-Agent-Session-Id / X-Agent-Type request headers. Both optional so
+   * existing single-agent callers and existing audit-log consumers keep
+   * working unchanged. Charset and length are already validated upstream
+   * by the proxy's identity-header parser; the audit log is never the
+   * source of truth for identity-header schema, just a downstream consumer.
+   */
+  readonly sessionId?: string;
+  readonly agentType?: string;
 }
 
 /**

--- a/src/mcp-proxy/logger.ts
+++ b/src/mcp-proxy/logger.ts
@@ -25,12 +25,12 @@ export interface AuditEntry {
    */
   readonly errorMessage?: string;
   /**
-   * Phase 2 Tier 1.2 (#53): per-agent identity propagated from
-   * X-Agent-Session-Id / X-Agent-Type request headers. Both optional so
-   * existing single-agent callers and existing audit-log consumers keep
-   * working unchanged. Charset and length are already validated upstream
-   * by the proxy's identity-header parser; the audit log is never the
-   * source of truth for identity-header schema, just a downstream consumer.
+   * Per-agent identity propagated from X-Agent-Session-Id / X-Agent-Type
+   * request headers (#53). Both optional so existing single-agent callers
+   * and existing audit-log consumers keep working unchanged. Charset and
+   * length are validated upstream by `parseIdentityHeader` in
+   * `src/mcp-proxy/server.ts`; the audit log is never the source of truth
+   * for identity-header schema, just a downstream consumer.
    */
   readonly sessionId?: string;
   readonly agentType?: string;

--- a/src/mcp-proxy/server.ts
+++ b/src/mcp-proxy/server.ts
@@ -215,6 +215,13 @@ export function createProxyServer(config: ProxyServerConfig): Express {
     let requestId: number | string | null = null; // Hoisted for catch block (#N-3)
     let toolName: string | undefined; // Hoisted so outer catch can emit a span (#C2)
     let activeTrace: ActiveTrace | undefined;
+    // Tier 1.2 (#53): hoisted so the closure-captured `audit()` and the
+    // outer-catch path both see the same identity values. Both remain
+    // undefined until the headers are parsed in the try block; an exception
+    // thrown before that (e.g. malformed JSON-RPC envelope) just produces
+    // an audit entry without identity, which is correct.
+    let sessionId: string | undefined;
+    let agentType: string | undefined;
 
     // Belt-and-braces defense around ActiveTrace calls. The enabled langfuse
     // tracer already isolates SDK errors inside span/end — but a custom
@@ -253,7 +260,11 @@ export function createProxyServer(config: ProxyServerConfig): Express {
       // The block-reason label still distinguishes WHY it was blocked.
       const toolLabel = entry.status === "blocked" ? "_blocked" : entry.tool;
       try {
-        recorder.recordRequest(toolLabel, entry.status, entry.durationMs ?? 0);
+        // Tier 1.2 (#53): pass entry.agentType through as a Prometheus label.
+        // The recorder maps undefined → AGENT_TYPE_UNSPECIFIED so every series
+        // carries the same label set regardless of whether the identity
+        // header was sent.
+        recorder.recordRequest(toolLabel, entry.status, entry.durationMs ?? 0, entry.agentType);
       } catch (err) {
         reqLog.warn({ err }, "recorder.recordRequest threw (ignored)");
       }
@@ -292,6 +303,12 @@ export function createProxyServer(config: ProxyServerConfig): Express {
         durationMs: Date.now() - start,
         direction,
         ...(errorMessage !== undefined ? { errorMessage } : {}),
+        // Tier 1.2 (#53): identity captured from headers earlier in the
+        // request, propagated to every audit entry so downstream consumers
+        // (NDJSON readers, MC, Prometheus) demux per-agent. Optional —
+        // when no headers are sent, the entry shape matches Phase 1 exactly.
+        ...(sessionId !== undefined ? { sessionId } : {}),
+        ...(agentType !== undefined ? { agentType } : {}),
       };
       logAuditEntry(entry);
       safeEmit(entry);
@@ -321,14 +338,15 @@ export function createProxyServer(config: ProxyServerConfig): Express {
 
       // Phase 2 Tier 1.1: extract identity headers. Both are optional; missing
       // → undefined preserves Phase 1 behaviour. Malformed → warn-log + undefined
-      // (must never 400-reject, #C5).
-      const sessionId = parseIdentityHeader(
+      // (must never 400-reject, #C5). Assign to the hoisted closure variables
+      // so the audit() helper and outer-catch path see the same identity.
+      sessionId = parseIdentityHeader(
         req.header("x-agent-session-id"),
         "X-Agent-Session-Id",
         SESSION_ID_MAX_LEN,
         reqLog
       );
-      const agentType = parseIdentityHeader(
+      agentType = parseIdentityHeader(
         req.header("x-agent-type"),
         "X-Agent-Type",
         AGENT_TYPE_MAX_LEN,

--- a/src/mcp-proxy/server.ts
+++ b/src/mcp-proxy/server.ts
@@ -260,10 +260,8 @@ export function createProxyServer(config: ProxyServerConfig): Express {
       // The block-reason label still distinguishes WHY it was blocked.
       const toolLabel = entry.status === "blocked" ? "_blocked" : entry.tool;
       try {
-        // Tier 1.2 (#53): pass entry.agentType through as a Prometheus label.
-        // The recorder maps undefined → AGENT_TYPE_UNSPECIFIED so every series
-        // carries the same label set regardless of whether the identity
-        // header was sent.
+        // entry.agentType becomes a Prometheus label; the recorder maps
+        // undefined → AGENT_TYPE_UNSPECIFIED (see `src/observability/metrics.ts`).
         recorder.recordRequest(toolLabel, entry.status, entry.durationMs ?? 0, entry.agentType);
       } catch (err) {
         reqLog.warn({ err }, "recorder.recordRequest threw (ignored)");

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -11,8 +11,28 @@ const log = childLogger("metrics");
 /** Block reason categories — closed union so cardinality is bounded and typos fail at compile time. */
 export type BlockReason = "allowlist" | "path_guard" | "no_route" | "unknown";
 
+/**
+ * Sentinel `agentType` label value used when no X-Agent-Type header was sent.
+ * Keeping the label present in every series — rather than emitting two
+ * different series shapes depending on whether the header was set — means
+ * Prometheus queries can group/sum over `agentType` without special-casing.
+ *
+ * Cardinality is operator-controlled via the X-Agent-Type charset/length
+ * limits enforced by the proxy's identity-header parser, so the label set
+ * stays bounded.
+ */
+export const AGENT_TYPE_UNSPECIFIED = "unspecified";
+
 export interface MetricsRecorder {
-  recordRequest(tool: string, status: AuditStatus, durationMs: number): void;
+  /**
+   * Record one terminal pipeline outcome.
+   *
+   * `agentType` is the optional value of the X-Agent-Type header carried
+   * through from the proxy's audit pipeline (Tier 1.2 / #53). When undefined
+   * the recorder labels the series with `AGENT_TYPE_UNSPECIFIED` so Prometheus
+   * sees the same label set on every emitted series.
+   */
+  recordRequest(tool: string, status: AuditStatus, durationMs: number, agentType?: string): void;
   recordInjectionFlag(pattern: string): void;
   recordBlockedRequest(reason: BlockReason): void;
   metricsText(): Promise<{ contentType: string; body: string }>;
@@ -70,15 +90,15 @@ export async function createMetricsRecorder(config: MetricsConfig): Promise<Metr
 
   const requestCounter = new promClient.Counter({
     name: "mcp_proxy_requests_total",
-    help: "Total MCP proxy requests, partitioned by tool and status",
-    labelNames: ["tool", "status"],
+    help: "Total MCP proxy requests, partitioned by tool, status, and agentType",
+    labelNames: ["tool", "status", "agentType"],
     registers: [register],
   });
 
   const requestDuration = new promClient.Histogram({
     name: "mcp_proxy_request_duration_seconds",
-    help: "MCP proxy request duration in seconds, partitioned by tool and status",
-    labelNames: ["tool", "status"],
+    help: "MCP proxy request duration in seconds, partitioned by tool, status, and agentType",
+    labelNames: ["tool", "status", "agentType"],
     buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10],
     registers: [register],
   });
@@ -101,10 +121,11 @@ export async function createMetricsRecorder(config: MetricsConfig): Promise<Metr
   promClient.collectDefaultMetrics({ register });
 
   return {
-    recordRequest(tool, status, durationMs) {
+    recordRequest(tool, status, durationMs, agentType) {
+      const labels = { tool, status, agentType: agentType ?? AGENT_TYPE_UNSPECIFIED };
       try {
-        requestCounter.inc({ tool, status });
-        requestDuration.observe({ tool, status }, durationMs / 1000);
+        requestCounter.inc(labels);
+        requestDuration.observe(labels, durationMs / 1000);
       } catch (err) {
         log.warn({ err }, "recordRequest failed (ignored)");
       }

--- a/tests/dashboard/adapter.test.ts
+++ b/tests/dashboard/adapter.test.ts
@@ -193,4 +193,64 @@ describe("createMissionControlAdapter", () => {
   it("shutdown resolves without throwing", async () => {
     await expect(adapter.shutdown()).resolves.toBeUndefined();
   });
+
+  // ── Tier 1.2 — agent identity in MC POST body ───────────────────────────
+  // pushActivity translates ActivityEvent → MC `/api/hermes/events` POST body.
+  // With identity propagation, agent_name now uses event.agentType (when
+  // present) so MC's panels can demultiplex per agent role; data.session_id
+  // is set when event.sessionId is present so MC can group activity by session.
+
+  it("pushActivity uses agentType for agent_name when ActivityEvent has agentType", async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true });
+    await adapter.pushActivity({
+      type: "tool_call",
+      tool: "Read",
+      timestamp: "2026-05-07T00:00:00.000Z",
+      status: "allowed",
+      agentType: "reviewer",
+    });
+    const [, opts] = fetchSpy.mock.calls[0]!;
+    const body = JSON.parse(opts.body);
+    expect(body.agent_name).toBe("reviewer");
+  });
+
+  it("pushActivity falls back to 'agentic-press-proxy' for agent_name when agentType is absent", async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true });
+    await adapter.pushActivity({
+      type: "tool_call",
+      tool: "Read",
+      timestamp: "2026-05-07T00:00:00.000Z",
+      status: "allowed",
+    });
+    const [, opts] = fetchSpy.mock.calls[0]!;
+    const body = JSON.parse(opts.body);
+    expect(body.agent_name).toBe("agentic-press-proxy");
+  });
+
+  it("pushActivity includes data.session_id when ActivityEvent has sessionId", async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true });
+    await adapter.pushActivity({
+      type: "tool_call",
+      tool: "Read",
+      timestamp: "2026-05-07T00:00:00.000Z",
+      status: "allowed",
+      sessionId: "task-001",
+    });
+    const [, opts] = fetchSpy.mock.calls[0]!;
+    const body = JSON.parse(opts.body);
+    expect(body.data.session_id).toBe("task-001");
+  });
+
+  it("pushActivity omits data.session_id when sessionId is absent (Phase 1 shape)", async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true });
+    await adapter.pushActivity({
+      type: "tool_call",
+      tool: "Read",
+      timestamp: "2026-05-07T00:00:00.000Z",
+      status: "allowed",
+    });
+    const [, opts] = fetchSpy.mock.calls[0]!;
+    const body = JSON.parse(opts.body);
+    expect(body.data.session_id).toBeUndefined();
+  });
 });

--- a/tests/dashboard/event-bridge.test.ts
+++ b/tests/dashboard/event-bridge.test.ts
@@ -156,4 +156,36 @@ describe("createEventBridge", () => {
     await bridge.shutdown();
     expect(adapter.shutdown).toHaveBeenCalledTimes(1);
   });
+
+  // ── Tier 1.2 — identity propagation ──────────────────────────────────────
+
+  it("propagates entry.sessionId to ActivityEvent.sessionId", async () => {
+    bridge.emit(makeEntry({ sessionId: "task-001" }));
+    await bridge.flush();
+    const event: ActivityEvent = adapter.pushActivity.mock.calls[0]![0];
+    expect(event.sessionId).toBe("task-001");
+  });
+
+  it("propagates entry.agentType to ActivityEvent.agentType", async () => {
+    bridge.emit(makeEntry({ agentType: "reviewer" }));
+    await bridge.flush();
+    const event: ActivityEvent = adapter.pushActivity.mock.calls[0]![0];
+    expect(event.agentType).toBe("reviewer");
+  });
+
+  it("propagates both identity fields together", async () => {
+    bridge.emit(makeEntry({ sessionId: "task-002", agentType: "coder" }));
+    await bridge.flush();
+    const event: ActivityEvent = adapter.pushActivity.mock.calls[0]![0];
+    expect(event.sessionId).toBe("task-002");
+    expect(event.agentType).toBe("coder");
+  });
+
+  it("omits sessionId/agentType from ActivityEvent when entry has neither (Phase 1 shape)", async () => {
+    bridge.emit(makeEntry());
+    await bridge.flush();
+    const event: ActivityEvent = adapter.pushActivity.mock.calls[0]![0];
+    expect(event.sessionId).toBeUndefined();
+    expect(event.agentType).toBeUndefined();
+  });
 });

--- a/tests/observability/metrics-server.test.ts
+++ b/tests/observability/metrics-server.test.ts
@@ -83,6 +83,38 @@ describe("metrics HTTP server", () => {
       expect(parseInt(match[1]!, 10)).toBeGreaterThanOrEqual(3);
     }
   });
+
+  // ── Tier 1.2 (#53) — agentType label end-to-end ─────────────────────────
+  // These tests pin the contract between the server's `safeRecord(undefined)`
+  // call and the actual Prometheus output. If someone removes the
+  // `?? AGENT_TYPE_UNSPECIFIED` fallback the unspecified test below catches it;
+  // if someone drops the `agentType` from the labelNames array the explicit
+  // test fails because the label cannot appear in the output.
+
+  it("recordRequest with no agentType emits the AGENT_TYPE_UNSPECIFIED sentinel label", async () => {
+    recorder.recordRequest("Read", "allowed", 5);
+    const res = await fetch(url);
+    const body = await res.text();
+    expect(body).toMatch(/mcp_proxy_requests_total\{[^}]*agentType="unspecified"[^}]*\}/);
+  });
+
+  it("recordRequest with explicit agentType emits the corresponding label value", async () => {
+    recorder.recordRequest("Read", "allowed", 5, "reviewer");
+    recorder.recordRequest("Read", "allowed", 7, "coder");
+    const res = await fetch(url);
+    const body = await res.text();
+    expect(body).toMatch(/mcp_proxy_requests_total\{[^}]*agentType="reviewer"[^}]*\}/);
+    expect(body).toMatch(/mcp_proxy_requests_total\{[^}]*agentType="coder"[^}]*\}/);
+  });
+
+  it("histogram emits the agentType label too (so duration queries can group by agent)", async () => {
+    recorder.recordRequest("Read", "allowed", 5, "reviewer");
+    const res = await fetch(url);
+    const body = await res.text();
+    // Histograms emit _bucket lines; assert the agentType label appears on at
+    // least one bucket line for the reviewer series.
+    expect(body).toMatch(/mcp_proxy_request_duration_seconds_bucket\{[^}]*agentType="reviewer"[^}]*\}/);
+  });
 });
 
 describe("metrics HTTP server — error path", () => {

--- a/tests/server-identity-propagation.test.ts
+++ b/tests/server-identity-propagation.test.ts
@@ -200,6 +200,46 @@ describe("Tier 1.2 — identity propagation through audit / events / metrics", (
     });
   });
 
+  describe("Outer-catch path", () => {
+    // The proxy hoists sessionId/agentType to the request-handler closure
+    // specifically so the outer-catch's audit() call still sees identity.
+    // This test anchors that behaviour — a future refactor that re-introduces
+    // `const` inside the try block would silently produce identity-less
+    // audit entries on error paths and this assertion would catch it.
+    it("identity is included in audit entries emitted from the outer-catch (sync bridge throw)", async () => {
+      // A bridge whose .call() throws synchronously short-circuits the
+      // promise machinery and lands in the outer try/catch.
+      const throwingBridge = {
+        call: () => { throw new Error("sync bridge explosion"); },
+        shutdown: async () => {},
+      } as unknown as StdioBridge;
+
+      // Spin up a dedicated server with the throwing bridge; the shared
+      // beforeEach's bridge does not throw, so we replace it here.
+      await closeServer(server);
+      const started = await startServer(makeConfig({
+        bridge: throwingBridge,
+        serverRoutes: { Read: "fs" },
+        eventBridge,
+        recorder,
+      }));
+      server = started.server;
+      url = started.url;
+
+      auditEntries.length = 0;
+      await mcpCall(url, 99, "Read", { path: "./pkg.json" }, {
+        "X-Agent-Session-Id": "task-outer-catch",
+        "X-Agent-Type": "coder",
+      });
+      const errorEntry = auditEntries.find(
+        (e: unknown) => (e as AuditEntry).status === "error"
+      ) as AuditEntry | undefined;
+      expect(errorEntry).toBeDefined();
+      expect(errorEntry!.sessionId).toBe("task-outer-catch");
+      expect(errorEntry!.agentType).toBe("coder");
+    });
+  });
+
   describe("MetricsRecorder agentType label", () => {
     it("recordRequest receives agentType as the 4th positional arg when X-Agent-Type is sent", async () => {
       await mcpCall(url, 20, "Read", { path: "./pkg.json" }, { "X-Agent-Type": "reviewer" });

--- a/tests/server-identity-propagation.test.ts
+++ b/tests/server-identity-propagation.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+
+/**
+ * Phase 2 Tier 1.2 — identity (sessionId / agentType) propagated by the proxy
+ * through audit, event bridge, and metrics surfaces. Tier 1.1 (#51, merged in
+ * #52) wired the headers into Langfuse traces; this file covers the remaining
+ * three surfaces so all four observability streams demultiplex per-agent.
+ */
+
+const { mockLogger, auditEntries } = vi.hoisted(() => {
+  const mockLogger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn(),
+  };
+  mockLogger.child.mockReturnValue(mockLogger);
+  const auditEntries: unknown[] = [];
+  return { mockLogger, auditEntries };
+});
+vi.mock("../src/logger.js", () => ({
+  default: mockLogger, childLogger: vi.fn(() => mockLogger),
+}));
+vi.mock("../src/mcp-proxy/logger.js", () => ({
+  logAuditEntry: vi.fn((entry: unknown) => {
+    auditEntries.push(entry);
+  }),
+}));
+
+import { createProxyServer, type ProxyServerConfig } from "../src/mcp-proxy/server.js";
+import type { EventBridge } from "../src/dashboard/event-bridge.js";
+import type { MetricsRecorder } from "../src/observability/metrics.js";
+import type { StdioBridge } from "../src/mcp-proxy/stdio-bridge.js";
+import type { AuditEntry } from "../src/mcp-proxy/logger.js";
+
+interface SpyEventBridge extends EventBridge {
+  emit: ReturnType<typeof vi.fn>;
+}
+
+interface SpyRecorder extends MetricsRecorder {
+  recordRequest: ReturnType<typeof vi.fn>;
+}
+
+function makeBridge(): StdioBridge {
+  return {
+    call: vi.fn(async () => ({ content: "ok" })),
+    shutdown: vi.fn(async () => {}),
+  } as unknown as StdioBridge;
+}
+
+function makeSpyEventBridge(): SpyEventBridge {
+  return {
+    emit: vi.fn(),
+    flush: vi.fn(async () => {}),
+    shutdown: vi.fn(async () => {}),
+  };
+}
+
+function makeSpyRecorder(): SpyRecorder {
+  return {
+    recordRequest: vi.fn(),
+    recordInjectionFlag: vi.fn(),
+    recordBlockedRequest: vi.fn(),
+    metricsText: vi.fn(async () => ({ contentType: "text/plain", body: "" })),
+    shutdown: vi.fn(async () => {}),
+  };
+}
+
+function makeConfig(overrides: Partial<ProxyServerConfig> = {}): ProxyServerConfig {
+  return {
+    port: 0,
+    allowedTools: ["Read"],
+    logLevel: "error",
+    ...overrides,
+  };
+}
+
+async function startServer(config: ProxyServerConfig): Promise<{ server: Server; url: string }> {
+  const app = createProxyServer(config);
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const addr = server.address() as AddressInfo;
+  return { server, url: `http://127.0.0.1:${addr.port}/mcp` };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function mcpCall(
+  url: string,
+  id: number,
+  toolName: string,
+  args: Record<string, unknown> = {},
+  headers: Record<string, string> = {}
+) {
+  return fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: { name: toolName, arguments: args },
+    }),
+  });
+}
+
+describe("Tier 1.2 — identity propagation through audit / events / metrics", () => {
+  let server: Server;
+  let url: string;
+  let eventBridge: SpyEventBridge;
+  let recorder: SpyRecorder;
+
+  beforeEach(async () => {
+    auditEntries.length = 0;
+    eventBridge = makeSpyEventBridge();
+    recorder = makeSpyRecorder();
+    const started = await startServer(makeConfig({
+      bridge: makeBridge(),
+      serverRoutes: { Read: "fs" },
+      eventBridge,
+      recorder,
+    }));
+    server = started.server;
+    url = started.url;
+  });
+
+  afterEach(async () => {
+    await closeServer(server);
+  });
+
+  describe("AuditEntry", () => {
+    it("includes sessionId and agentType when both headers are sent", async () => {
+      await mcpCall(url, 1, "Read", { path: "./pkg.json" }, {
+        "X-Agent-Session-Id": "task-001",
+        "X-Agent-Type": "reviewer",
+      });
+      const lastEntry = auditEntries.at(-1) as AuditEntry;
+      expect(lastEntry.sessionId).toBe("task-001");
+      expect(lastEntry.agentType).toBe("reviewer");
+    });
+
+    it("omits sessionId and agentType when no headers are sent (Phase 1 backward compat)", async () => {
+      await mcpCall(url, 2, "Read", { path: "./pkg.json" });
+      const lastEntry = auditEntries.at(-1) as AuditEntry;
+      expect(lastEntry.sessionId).toBeUndefined();
+      expect(lastEntry.agentType).toBeUndefined();
+    });
+
+    it("includes only sessionId when only X-Agent-Session-Id is sent", async () => {
+      await mcpCall(url, 3, "Read", {}, { "X-Agent-Session-Id": "sess-only" });
+      const lastEntry = auditEntries.at(-1) as AuditEntry;
+      expect(lastEntry.sessionId).toBe("sess-only");
+      expect(lastEntry.agentType).toBeUndefined();
+    });
+
+    it("propagates identity to blocked-status audit entries (allowlist reject)", async () => {
+      await mcpCall(url, 4, "Forbidden", {}, {
+        "X-Agent-Session-Id": "task-002",
+        "X-Agent-Type": "coder",
+      });
+      const blockedEntry = auditEntries.find(
+        (e: unknown) => (e as AuditEntry).status === "blocked"
+      ) as AuditEntry | undefined;
+      expect(blockedEntry).toBeDefined();
+      expect(blockedEntry!.sessionId).toBe("task-002");
+      expect(blockedEntry!.agentType).toBe("coder");
+    });
+
+    it("falls through cleanly when malformed identity headers are sent (Tier 1.1 invariant preserved)", async () => {
+      await mcpCall(url, 5, "Read", { path: "./pkg.json" }, {
+        "X-Agent-Session-Id": "bad value!",
+      });
+      const lastEntry = auditEntries.at(-1) as AuditEntry;
+      // Malformed header → identity dropped → audit entry has no sessionId.
+      // Anchor #C5: malformed identity must not break the request, so the
+      // call still produces an audit entry with status=allowed.
+      expect(lastEntry.sessionId).toBeUndefined();
+      expect(lastEntry.status).toBe("allowed");
+    });
+  });
+
+  describe("EventBridge ActivityEvent", () => {
+    it("emit receives an entry with sessionId and agentType when headers are sent", async () => {
+      await mcpCall(url, 10, "Read", {}, {
+        "X-Agent-Session-Id": "task-100",
+        "X-Agent-Type": "tester",
+      });
+      const lastEmit = eventBridge.emit.mock.calls.at(-1)![0] as AuditEntry;
+      expect(lastEmit.sessionId).toBe("task-100");
+      expect(lastEmit.agentType).toBe("tester");
+    });
+
+    it("emit omits sessionId/agentType when no headers (Phase 1 shape)", async () => {
+      await mcpCall(url, 11, "Read", { path: "./pkg.json" });
+      const lastEmit = eventBridge.emit.mock.calls.at(-1)![0] as AuditEntry;
+      expect(lastEmit.sessionId).toBeUndefined();
+      expect(lastEmit.agentType).toBeUndefined();
+    });
+  });
+
+  describe("MetricsRecorder agentType label", () => {
+    it("recordRequest receives agentType as the 4th positional arg when X-Agent-Type is sent", async () => {
+      await mcpCall(url, 20, "Read", { path: "./pkg.json" }, { "X-Agent-Type": "reviewer" });
+      const lastCall = recorder.recordRequest.mock.calls.at(-1)!;
+      expect(lastCall[3]).toBe("reviewer");
+    });
+
+    it("recordRequest receives undefined agentType when no header is sent (recorder maps to sentinel internally)", async () => {
+      await mcpCall(url, 21, "Read", { path: "./pkg.json" });
+      const lastCall = recorder.recordRequest.mock.calls.at(-1)!;
+      expect(lastCall[3]).toBeUndefined();
+    });
+
+    it("two requests with distinct agentTypes record distinct label values", async () => {
+      await mcpCall(url, 30, "Read", {}, { "X-Agent-Type": "reviewer" });
+      await mcpCall(url, 31, "Read", {}, { "X-Agent-Type": "coder" });
+      const calls = recorder.recordRequest.mock.calls;
+      const reviewer = calls.find((c) => c[3] === "reviewer");
+      const coder = calls.find((c) => c[3] === "coder");
+      expect(reviewer).toBeDefined();
+      expect(coder).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Second Phase 2 increment — completes identity-header propagation across all four observability surfaces. Tier 1.1 (#52) wired the headers into Langfuse traces; this PR extends the same identity to the audit log, the dashboard event bridge → Mission Control POST body, and Prometheus.

## Summary

- **`AuditEntry`** gains optional `sessionId` and `agentType` fields. Existing NDJSON readers see Phase 1 shape exactly when no headers are sent.
- **MC adapter** (`src/dashboard/adapter.ts`): `agent_name` in the POST body now uses `event.agentType` when present (e.g. \"reviewer\"), falling back to a new `DEFAULT_AGENT_NAME = \"agentic-press-proxy\"` constant. `data.session_id` is included when present, omitted entirely when absent.
- **Event bridge**: propagates both fields from `AuditEntry` to `ActivityEvent` so the adapter sees a clean shape.
- **Prometheus** (`src/observability/metrics.ts`): `mcp_proxy_requests_total` and `mcp_proxy_request_duration_seconds` gain an `agentType` label. Undefined values map to `AGENT_TYPE_UNSPECIFIED` so every series carries the same label set. Cardinality bounded by Tier 1.1's X-Agent-Type charset/length limits.
- **Server**: `sessionId`/`agentType` are hoisted to the request-handler closure so the `audit()` helper and outer-catch path see the same identity values. Pre-parse exceptions correctly produce identity-less audit entries.

## Plan deviation

The plan called for new tests to be folded into existing `tests/server-{audit-log,dashboard,metrics}.test.ts` files. I chose a single new `tests/server-identity-propagation.test.ts` to match the Tier 1.1 pattern (`tests/server-identity-headers.test.ts`) and keep the diff cohesive. Dashboard-level unit tests still live in `tests/dashboard/*.test.ts`.

## Out of scope (deferred to later increments)

- Per-session allowlist registry — Tier 1.3 (#TBD).
- Multi-agent dispatch CLI / acceptance test — Tier 1.4 / 1.5.
- MC connection adapter (`POST /api/connect`, heartbeat, queue-poll) — Tier 2.A.

## Test plan

- [x] `npm test` — 594 → 612 (+18)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] New tests in `tests/server-identity-propagation.test.ts` cover the end-to-end wiring from request headers to AuditEntry, EventBridge, and MetricsRecorder
- [x] `tests/dashboard/adapter.test.ts` (+4) covers the agent_name + session_id fallback behaviour at the MC POST body level
- [x] `tests/dashboard/event-bridge.test.ts` (+4) covers identity propagation from AuditEntry → ActivityEvent
- [x] Backward compat: \"omits when no headers\" assertions in every new test group
- [ ] Live curl with identity headers produces an MC `/api/hermes/events` POST with `agent_name=<type>` and `data.session_id=<id>` (manual smoke after merge, optional)

Closes #53