### PR TITLE
feat: Tier 1.3 — per-session allowlist registry + loopback control-plane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,25 @@ LOG_LEVEL=info
 # Mission Control (optional — proxy works without these)
 # MISSION_CONTROL_URL=http://localhost:3000
 # MISSION_CONTROL_API_KEY=
+
+# Per-session allowlist control plane (Tier 1.3 / #56)
+# When MCP_CONTROL_TOKEN is set, the proxy starts a SECOND HTTP listener on
+# 127.0.0.1:18924 (loopback only — sandboxes cannot reach it). The dispatch
+# CLI / Mission Control connector uses this surface to register/deregister
+# per-session allowlists; a request carrying X-Agent-Session-Id whose session
+# is registered uses the per-session allowlist, else falls through to the
+# global ALLOWED_TOOLS list.
+#
+# When MCP_CONTROL_TOKEN is UNSET, the control plane does NOT start and the
+# proxy continues with the global allowlist exactly as Phase 1 — no surprise.
+#
+# 32+ random bytes hex-encoded (e.g. `openssl rand -hex 32`). NEVER paste this
+# value into a sandbox, NEVER pass it via `sbx exec --env`, NEVER commit it
+# to source. Treat as a secret on par with API keys.
+# MCP_CONTROL_TOKEN=YOUR_LONG_RANDOM_HEX_HERE
+
+# Listen port for the control plane. The bind address is hard-coded to
+# "127.0.0.1" — there is intentionally no env knob to widen it (sandbox-side
+# processes can reach host.docker.internal but not the host's loopback iface,
+# so loopback is the primary defence; widening it would void that).
+# MCP_CONTROL_PORT=18924

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,9 @@ flowchart LR
   end
   subgraph HOST["host machine"]
     P["MCP proxy<br/>(Express, :18923)"]
+    CP["control plane<br/>(Express, 127.0.0.1:18924)"]
+    REG[("session<br/>registry")]
+    DCLI["dispatch CLI / MC connector<br/>(holds MCP_CONTROL_TOKEN)"]
     B["stdio bridge"]
     H["http bridge"]
     M1["MCP server:<br/>filesystem"]
@@ -31,7 +34,10 @@ flowchart LR
   subgraph REMOTE["remote (Phase 2)"]
     M3["MCP server:<br/>https://...<br/>(container/Lambda)"]
   end
-  A -- "JSON-RPC / HTTP<br/>host.docker.internal:18923" --> P
+  A -- "JSON-RPC / HTTP<br/>host.docker.internal:18923<br/>X-Agent-Session-Id" --> P
+  DCLI -- "Bearer token<br/>POST/DELETE /sessions" --> CP
+  CP -- writes --> REG
+  P -- reads --> REG
   P -- "JSON-RPC / stdio" --> B
   P -- "JSON-RPC / HTTPS<br/>Bearer auth" --> H
   B --> M1
@@ -45,6 +51,8 @@ flowchart LR
   P -- "NDJSON audit" --> LOG[("stdout audit stream")]
   P -- "pino JSON" --> DIAG[("stdout diagnostic stream")]
 ```
+
+The proxy port (`0.0.0.0:18923`) is reachable from sandboxes via `host.docker.internal`; the control-plane port (`127.0.0.1:18924`) is **not** — it binds to loopback so only host-side processes (the dispatch CLI / Mission Control connector) can register or query sessions. See [`./security.md`](./security.md#control-plane-trust-boundary) for the threat model.
 
 ## Request pipeline
 
@@ -127,7 +135,7 @@ The proxy enforces three independent controls. Defense in depth is intentional �
 
 | Control | File | Blocks |
 |---|---|---|
-| allowlist | `src/mcp-proxy/allowlist.ts` | Any tool name not matching a configured pattern. Malformed config blocks everything. |
+| allowlist | `src/mcp-proxy/allowlist.ts` (+ `src/orchestrator/session-registry.ts` for per-session) | Any tool name not matching a configured pattern. Malformed config blocks everything. When the request carries `X-Agent-Session-Id` and the session is registered via the control plane, the per-session allowlist takes precedence; otherwise the global `ALLOWED_TOOLS` list applies (Phase 1 default). |
 | sanitizer (request + response) | `src/mcp-proxy/sanitizer.ts`, `src/mcp-proxy/response-sanitizer.ts`, `src/security/injection-patterns.ts` | Prompt-injection text, turn-boundary markers, zero-width unicode, dangerous base64, `<script>` / iframe / event-handler markup, `javascript:` URIs, markdown image exfiltration, injected `tools` / `function_call` / `</tool_result>` fragments — applied to **both** request arguments and upstream responses. Clean-room patterns sourced from OWASP LLM Top 10, the MCP spec, and published CVEs (incl. CVE-2025-6514). |
 | path guard | `src/security/path-guard.ts` | Null bytes, backslashes, drive letters, encoded traversal (`%2e%2e`, double-encoded, overlong UTF-8, fullwidth), logical escape from `workspaceRoot`, symlink escape (CVE-2025-53109), containment bypass (CVE-2025-53110). |
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -105,6 +105,43 @@ The proxy is one layer in a defense-in-depth strategy. The following concerns ar
 - **Workspace secret hygiene.** The allowlist does not distinguish credential files from any other file. Keep secrets out of the sandbox workspace; mount them only through sbx's secret-management surface.
 - **Defense-in-depth for prompt injection.** Pattern-based detection is one layer; combine it with output validation, content provenance checks, and human-in-the-loop confirmation for high-stakes tool calls. Use `block` mode for high-assurance deployments.
 
+## Control-plane trust boundary
+
+Tier 1.3 (#56) introduces a **second HTTP listener** alongside the proxy: the control-plane server. The proxy serves untrusted sandbox traffic on `0.0.0.0:18923`; the control plane handles privileged session-registry mutations on `127.0.0.1:18924`. A sandbox-side process registering a permissive allowlist for itself would defeat the entire per-session policy, so the control plane's trust boundary is non-negotiable.
+
+**Two layers, belt-and-braces:**
+
+1. **Loopback bind** on `127.0.0.1:18924`. Sandboxes can reach `host.docker.internal` (the host's Docker bridge IP) but **not** the host's loopback interface — connections to `127.0.0.1:18924` from inside a sandbox are RST'd at the kernel. The bind is a hard-coded literal in `src/index.ts`; there is intentionally no env knob to widen it. Changing it requires a code change and security review.
+2. **Bearer-token gate** via the `MCP_CONTROL_TOKEN` env var on every endpoint except `GET /health`. Comparison uses `crypto.timingSafeEqual` with an explicit length check first (a wrong-length token returns 401, not 400 — preventing a length-probe distinguisher). When the token is unset at startup the control plane **does not start** and the proxy continues with the global allowlist as in Phase 1.
+
+**Threat decomposition.** "Sandbox escape" is six different concerns; each has a different defence:
+
+| # | Threat | Primary defence | Backstop | Out-of-scope / caveats |
+|---|---|---|---|---|
+| 1 | **Container escape (kernel-level)** — agent gets shell on host kernel via Docker / container exploit | sbx + Docker isolation, kernel patching | None at our layer | Operator responsibility; tracked under [Operator Responsibilities](#operator-responsibilities) |
+| 2 | **Network escape** — sandbox tries `curl http://host.docker.internal:18924/sessions` | Loopback bind on `127.0.0.1:18924`. `host.docker.internal` resolves to the Docker bridge IP, **not** `127.0.0.1`; connection refused | Bearer token | **Depends on sbx not running sandboxes with `--network host`.** Documented dependency on the sbx side. |
+| 3 | **Token theft** — agent obtains the bearer token | (a) Token never enters sandbox — host-side env only, never passed via `sbx exec --env`. (b) Token never logs (audit, trace, Prometheus, MC adapter, stdout). (c) 256-bit unguessable. (d) `crypto.timingSafeEqual` with explicit length check | Loopback bind: stolen token alone won't reach the port from outside the host | Operator footgun: pasting the token into a terminal whose stdout ends up in a sandbox-readable location leaks it. Documented but not enforced. |
+| 4 | **Identity spoofing** — agent A sets `X-Agent-Session-Id` to agent B's id to inherit B's allowlist | Dispatch CLI (Tier 1.4) mints session IDs as 16-byte random hex — unguessable. Per-sandbox workspace mounts (sbx default) prevent A from reading a file B wrote | Lookup precedence: a forged session id that doesn't exist in the registry falls through to the global allowlist (the most-restrictive baseline) | If operator deliberately gives two agents a shared workspace mount, one can leak its session id to the other. Documented sharp edge. |
+| 5 | **Confused deputy via dispatch CLI** — agent influences the dispatch CLI (which holds the token) into registering a permissive session for it | Tier 1.4 contract: dispatch CLI constructs the registration payload from operator-provided manifest only — never from sandbox stdout, never from sandbox-writable files | None at the control-plane layer (this lives one layer up) | Tier 1.3 must not preclude this contract. Future MC connectors must inherit it. |
+| 6 | **Self-elevation via /mcp** — agent calls a /mcp method that mutates the registry | Not a vector by construction: `/mcp` doesn't speak the control-plane protocol; the proxy reads but never writes the registry. Type-level guard: `ProxyServerConfig.registry` is `Pick<SessionRegistry, "lookup">`, so a TypeScript-level mistake won't compile | Code review for any new `/mcp` admin method | A future PR adding `/mcp/admin` would need explicit Plan-Mode approval. |
+
+**Defences explicitly NOT added:**
+
+| Not added | Reason |
+|---|---|
+| mTLS on control plane | Heavy. Single-user system. Loopback + token suffices. |
+| Per-token rate limiting | Loopback bind already restricts attack surface to host-only. Add later if it becomes a real signal. |
+| Token rotation without restart | Env-based config, restart-to-rotate. Acceptable single-user trade-off. |
+| Configurable bind via env var | Operator footgun that could silently void the primary defence. Hard-coded literal in source. |
+| Auto-generation of bearer token with stdout print | "Secret printed to logs" is a bad pattern even when intentional, and fragile if operator doesn't capture stdout. Explicit-only. |
+
+**Audit invariants for the control plane:**
+
+- Successful `POST /sessions` and `DELETE /sessions/:id` write a single `direction: "control-plane"` audit entry per call. Structured fields capture `action` (`register`/`deregister`), `sessionId`, `agentType`, `remoteAddress`, `remotePort`, and (for register only) `allowedToolsCount`.
+- The allowlist contents are **never** recorded — only the count of allowed tools — so an audit-log reader cannot derive an operator-private allowlist by scraping NDJSON.
+- 401 / 400 rejections write a warn-log only, **not** an audit entry. This prevents a probe burst from flooding the NDJSON file.
+- The token value never appears in any log line, audit entry, trace metadata, Prometheus output, or MC payload. Tested in `tests/orchestrator/control-plane.test.ts`.
+
 ## Verifying Defenses
 
 The test suite is organized to let a reviewer verify each mitigation in isolation:
@@ -113,5 +150,6 @@ The test suite is organized to let a reviewer verify each mitigation in isolatio
 - `tests/sanitizer.test.ts` — `flag` / `strip` / `block` modes, multi-injection handling, repeated-payload stripping.
 - `tests/path-guard.test.ts` — valid paths, traversal, encoded separators, null bytes, symlink escape, Windows-style rejection, edge cases.
 - `tests/allowlist.test.ts` — exact match, wildcard semantics, case sensitivity, malformed-config fail-closed behavior, `**` bypass guard.
+- `tests/orchestrator/session-registry.test.ts`, `tests/orchestrator/control-plane.test.ts`, `tests/server-per-session-allowlist.test.ts` — per-session allowlist + control-plane HTTP gate (Tier 1.3 / #56).
 
 Run `npm test` inside the sbx sandbox (see [development](./development.md)) after any change under `src/security/` or `src/mcp-proxy/sanitizer.ts`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -135,6 +135,13 @@ Tier 1.3 (#56) introduces a **second HTTP listener** alongside the proxy: the co
 | Configurable bind via env var | Operator footgun that could silently void the primary defence. Hard-coded literal in source. |
 | Auto-generation of bearer token with stdout print | "Secret printed to logs" is a bad pattern even when intentional, and fragile if operator doesn't capture stdout. Explicit-only. |
 
+**Per-session allowlist semantics:**
+
+A registered per-session allowlist *replaces* the global `ALLOWED_TOOLS` list for that session — it does not intersect with it. This is by design (the dispatch CLI is operator-controlled and trusted to enforce least-privilege per agent), but it means a permissive per-session policy could supersede a narrower global one. Two guardrails:
+
+- The control-plane validation layer **rejects bare catch-all patterns** (`*`, `**`) in `allowedTools`. A bare `*` has no least-privilege use case at the per-session layer; operators who want catch-all behaviour should rely on the global allowlist. Prefix wildcards like `echo__*` are accepted because they legitimately narrow.
+- A future PR adding intersect-with-global semantics (per-session can only narrow, never widen) would tighten this further. Tracked as a follow-up.
+
 **Audit invariants for the control plane:**
 
 - Successful `POST /sessions` and `DELETE /sessions/:id` write a single `direction: "control-plane"` audit entry per call. Structured fields capture `action` (`register`/`deregister`), `sessionId`, `agentType`, `remoteAddress`, `remotePort`, and (for register only) `allowedToolsCount`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,18 @@ try {
 // reach host.docker.internal but not the host's loopback iface). Changing it
 // requires a code change + security review.
 const controlToken = process.env.MCP_CONTROL_TOKEN?.trim();
+// Minimum token length. The plan specifies 32 random bytes hex-encoded
+// (64 chars), but we accept anything >= 32 chars to avoid being prescriptive
+// about encoding. Below 32 chars is brute-forceable; fail loudly at startup
+// rather than letting an operator silently weaken the defense-in-depth layer.
+// The loopback bind is the primary defense; this is the second layer.
+const MIN_CONTROL_TOKEN_LEN = 32;
+if (controlToken !== undefined && controlToken.length < MIN_CONTROL_TOKEN_LEN) {
+  throw new Error(
+    `MCP_CONTROL_TOKEN is too short (${controlToken.length} chars, min ${MIN_CONTROL_TOKEN_LEN}). ` +
+      `Generate a strong token with: openssl rand -hex 32`
+  );
+}
 const controlPort = parseInt(process.env.MCP_CONTROL_PORT ?? "18924", 10);
 if (isNaN(controlPort) || controlPort < 1 || controlPort > 65535) {
   throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ import {
   validateServerConfig,
   parseMaxResponseBytes,
 } from "./server-config.js";
+import { createSessionRegistry, type SessionRegistry } from "./orchestrator/session-registry.js";
+import { createControlPlaneServer } from "./orchestrator/control-plane.js";
 
 const log = childLogger("main");
 
@@ -171,6 +173,31 @@ try {
   eventBridge = createNoopEventBridge();
 }
 
+// Tier 1.3 (#56) — per-session allowlist registry + control-plane HTTP server.
+//
+// MCP_CONTROL_TOKEN is the bearer token that gates the control plane. Treat it
+// as a secret on par with API keys — NEVER log, never echo, never pass into a
+// sandbox via `sbx exec --env`. Operator sets it explicitly in .envrc; an
+// unset token disables the control plane entirely (the proxy continues with
+// the global allowlist exactly as Phase 1 did).
+//
+// MCP_CONTROL_PORT is the listen port; defaults to 18924. The bind address is
+// the literal "127.0.0.1" — there is intentionally NO env knob for the bind.
+// Widening the bind would void the loopback-isolation defence (sandboxes can
+// reach host.docker.internal but not the host's loopback iface). Changing it
+// requires a code change + security review.
+const controlToken = process.env.MCP_CONTROL_TOKEN?.trim();
+const controlPort = parseInt(process.env.MCP_CONTROL_PORT ?? "18924", 10);
+if (isNaN(controlPort) || controlPort < 1 || controlPort > 65535) {
+  throw new Error(
+    `Invalid MCP_CONTROL_PORT: "${process.env.MCP_CONTROL_PORT}" — must be 1-65535`
+  );
+}
+const sessionRegistry: SessionRegistry | undefined = controlToken
+  ? createSessionRegistry()
+  : undefined;
+let controlPlaneServer: import("node:http").Server | undefined;
+
 const config: ProxyServerConfig = {
   port,
   allowedTools: (process.env.ALLOWED_TOOLS ?? "").split(",").filter(Boolean),
@@ -180,6 +207,7 @@ const config: ProxyServerConfig = {
   tracer,
   eventBridge,
   recorder,
+  registry: sessionRegistry,
 };
 
 const app = createProxyServer(config);
@@ -194,6 +222,40 @@ const server = app.listen(config.port, "0.0.0.0", () => {
     );
   }
 });
+
+// Start the control-plane server only when a token is configured AND the
+// registry was created above. The bind address is hard-coded to "127.0.0.1"
+// — see comment above — so sandbox-side processes can't reach it via
+// host.docker.internal.
+if (sessionRegistry && controlToken) {
+  const controlPlaneApp = createControlPlaneServer({
+    registry: sessionRegistry,
+    token: controlToken,
+  });
+  controlPlaneServer = controlPlaneApp.listen(controlPort, "127.0.0.1", () => {
+    log.info(
+      { port: controlPort, bind: "127.0.0.1" },
+      "Control-plane endpoint listening (per-session allowlists enabled)"
+    );
+  });
+  // Async error events (EADDRINUSE, EACCES) escape the surrounding scope.
+  // Without this handler the whole process crashes — and a control-plane
+  // failure must NEVER take the proxy down (#C5: observability/orchestration
+  // failures never break the request path). Disable the control plane and
+  // continue serving with the global allowlist.
+  controlPlaneServer.on("error", (err) => {
+    log.warn(
+      { err, port: controlPort },
+      "Control-plane HTTP server failed to bind — control plane disabled, proxy continues"
+    );
+    controlPlaneServer = undefined;
+  });
+} else {
+  log.warn(
+    "MCP_CONTROL_TOKEN unset — control plane disabled, per-session allowlists unavailable. " +
+      "Set MCP_CONTROL_TOKEN to enable. See docs/security.md (control-plane trust boundary)."
+  );
+}
 
 // Graceful shutdown: close HTTP server first, then bridge + tracer, with 5s force-exit
 function shutdown(signal: string) {
@@ -227,6 +289,11 @@ function shutdown(signal: string) {
     if (metricsHttpServer) {
       tasks.push(
         new Promise<void>((resolve) => metricsHttpServer!.close(() => resolve()))
+      );
+    }
+    if (controlPlaneServer) {
+      tasks.push(
+        new Promise<void>((resolve) => controlPlaneServer!.close(() => resolve()))
       );
     }
     Promise.allSettled(tasks).then((results) => {

--- a/src/mcp-proxy/logger.ts
+++ b/src/mcp-proxy/logger.ts
@@ -2,7 +2,9 @@ import { closeSync, openSync, writeSync } from "node:fs";
 import type { SanitizeFlag } from "./sanitizer.js";
 import type { AuditStatus } from "../types.js";
 
-export type AuditDirection = "request" | "response";
+export type AuditDirection = "request" | "response" | "control-plane";
+
+export type ControlPlaneAction = "register" | "deregister";
 
 export interface AuditEntry {
   readonly timestamp: string;
@@ -14,7 +16,9 @@ export interface AuditEntry {
   /**
    * Which pipeline stage produced this entry. "request" covers allowlist,
    * request-arg sanitization, and path guard. "response" covers upstream
-   * MCP server response sanitization. Defaults to "request" when omitted.
+   * MCP server response sanitization. "control-plane" covers session-registry
+   * mutations (register/deregister) emitted by the control-plane server
+   * (Tier 1.3 / #56). Defaults to "request" when omitted.
    */
   readonly direction?: AuditDirection;
   /**
@@ -34,6 +38,16 @@ export interface AuditEntry {
    */
   readonly sessionId?: string;
   readonly agentType?: string;
+  /**
+   * Control-plane fields (Tier 1.3 / #56) — only set when
+   * `direction === "control-plane"`. The allowlist contents are NEVER
+   * recorded; only the count of allowed tools, so an audit-log reader cannot
+   * derive an operator-private allowlist by scraping NDJSON.
+   */
+  readonly action?: ControlPlaneAction;
+  readonly remoteAddress?: string;
+  readonly remotePort?: number;
+  readonly allowedToolsCount?: number;
 }
 
 /**

--- a/src/mcp-proxy/server.ts
+++ b/src/mcp-proxy/server.ts
@@ -18,6 +18,7 @@ import {
 } from "../observability/langfuse.js";
 import { createNoopEventBridge, type EventBridge } from "../dashboard/event-bridge.js";
 import { createNoopRecorder, type MetricsRecorder, type BlockReason } from "../observability/metrics.js";
+import type { SessionRegistry } from "../orchestrator/session-registry.js";
 
 const log = childLogger("mcp-proxy");
 
@@ -94,6 +95,16 @@ export interface ProxyServerConfig {
   readonly tracer?: Tracer;
   readonly eventBridge?: EventBridge;
   readonly recorder?: MetricsRecorder;
+  /**
+   * Tier 1.3 (#56) — optional per-session allowlist registry. When set, the
+   * proxy consults the registry on each /mcp request: if the request carries
+   * a parsed sessionId AND the registry has an entry for it, the per-session
+   * allowlist is used. Otherwise the request falls through to the global
+   * `allowedTools` config. Type is `Pick<SessionRegistry, "lookup">` so this
+   * code path can NEVER mutate the registry — only the control-plane server
+   * holds the writer.
+   */
+  readonly registry?: Pick<SessionRegistry, "lookup">;
 }
 
 interface JsonRpcRequest {
@@ -196,7 +207,7 @@ export function createProxyServer(config: ProxyServerConfig): Express {
 
   const allowlistConfig: AllowlistConfig = { patterns: [...config.allowedTools] };
   const workspaceRoot = config.workspaceRoot ?? process.env.WORKSPACE_ROOT ?? process.cwd();
-  const { bridge } = config;
+  const { bridge, registry } = config;
   const sortedRoutes = config.serverRoutes ? sortRoutes(config.serverRoutes) : undefined;
   const tracer: Tracer = config.tracer ?? createNoopTracer();
   const eventBridge: EventBridge = config.eventBridge ?? createNoopEventBridge();
@@ -394,8 +405,26 @@ export function createProxyServer(config: ProxyServerConfig): Express {
         activeTrace = undefined;
       }
 
-      // 1. Allowlist check
-      const allowResult = checkAllowlist(tool, allowlistConfig);
+      // 1. Allowlist check.
+      //
+      // Tier 1.3 (#56): consult the per-session registry when the request
+      // carries a parsed sessionId. The lookup is wrapped in try/catch so a
+      // misbehaving registry impl can NEVER reject the request — observability
+      // / orchestration failures fall through to the global allowlist with a
+      // warn-log (anchor #C5). A malformed sessionId from Tier 1.1 already
+      // arrives here as `undefined`, which short-circuits the lookup entirely.
+      let effectiveAllowlist: AllowlistConfig = allowlistConfig;
+      if (sessionId !== undefined && registry) {
+        try {
+          const entry = registry.lookup(sessionId);
+          if (entry) {
+            effectiveAllowlist = entry.allowlist;
+          }
+        } catch (err) {
+          reqLog.warn({ err, sessionId }, "session registry lookup threw — falling back to global allowlist");
+        }
+      }
+      const allowResult = checkAllowlist(tool, effectiveAllowlist);
       if (!allowResult.allowed) {
         audit(tool, toolArgs, "blocked", [], undefined, "request", "allowlist");
         safeSpan({ tool, status: "blocked", durationMs: Date.now() - start });

--- a/src/orchestrator/control-plane.ts
+++ b/src/orchestrator/control-plane.ts
@@ -1,8 +1,13 @@
 import express, { type Express, type Request, type Response, type NextFunction } from "express";
 import { timingSafeEqual } from "node:crypto";
 import { childLogger } from "../logger.js";
-import { logAuditEntry, type AuditEntry } from "../mcp-proxy/logger.js";
-import type { SessionRegistry } from "./session-registry.js";
+import { logAuditEntry } from "../mcp-proxy/logger.js";
+import {
+  SESSION_ID_PATTERN,
+  SESSION_ID_MAX_LEN,
+  validateSessionInput,
+  type SessionRegistry,
+} from "./session-registry.js";
 
 const log = childLogger("control-plane");
 
@@ -36,24 +41,6 @@ const log = childLogger("control-plane");
  * all see consistently bounded values.
  */
 
-const SESSION_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
-const AGENT_TYPE_PATTERN = /^[A-Za-z0-9._-]+$/;
-/**
- * Charset for allowedTools entries. Adds `*` (wildcard) on top of the
- * sessionId/agentType charset since matchesPattern() supports prefix-suffix
- * wildcards. Rejecting other characters closes a class of injection
- * vectors — null bytes, newlines, zero-width unicode (U+200B/FEFF/200D),
- * control characters — that would otherwise round-trip through any future
- * code path that logs or serialises pattern values. Today only the count
- * is recorded in audit, but this charset is the contract for future
- * surfaces (e.g. richer audit logging, MC display).
- */
-const ALLOWLIST_PATTERN_CHARSET = /^[A-Za-z0-9._*-]+$/;
-const SESSION_ID_MAX_LEN = 128;
-const AGENT_TYPE_MAX_LEN = 32;
-const ALLOWLIST_PATTERN_MAX_LEN = 256;
-const ALLOWLIST_MAX_ENTRIES = 256;
-
 export interface ControlPlaneServerConfig {
   readonly registry: SessionRegistry;
   readonly token: string;
@@ -69,84 +56,102 @@ function tokenMatches(provided: string, expected: string): boolean {
   if (provided.length !== expected.length) return false;
   try {
     return timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
-  } catch {
+  } catch (err) {
+    // timingSafeEqual is virtually unreachable on this path — same-length
+    // Buffers built from utf-8 strings shouldn't throw — but a silent `false`
+    // on an unexpected error would hide a real bug. Surface it via warn-log
+    // so operators see the failure mode if it ever fires. Still return false
+    // (treat as wrong token) so the auth contract is preserved.
+    log.warn({ err }, "tokenMatches: timingSafeEqual threw unexpectedly — treating as wrong token");
     return false;
   }
 }
 
-function emitControlPlaneAudit(entry: Omit<AuditEntry, "timestamp" | "tool" | "args" | "flags" | "status"> & {
-  readonly status?: AuditEntry["status"];
-}): void {
+/**
+ * Discriminated union for control-plane audit calls (F8). The compiler now
+ * enforces that register entries carry `allowedToolsCount` + `agentType`,
+ * and deregister entries do NOT. Previously a single Omit-based type
+ * accepted optional fields uniformly, so a deregister caller could mistakenly
+ * pass `allowedToolsCount` (or omit it on register) and TypeScript wouldn't
+ * catch it.
+ */
+export interface RegisterAuditFields {
+  readonly action: "register";
+  readonly sessionId: string;
+  readonly agentType: string;
+  readonly allowedToolsCount: number;
+  readonly remoteAddress: string;
+  readonly remotePort: number;
+}
+
+export interface DeregisterAuditFields {
+  readonly action: "deregister";
+  readonly sessionId: string;
+  readonly remoteAddress: string;
+  readonly remotePort: number;
+}
+
+export type ControlPlaneAuditFields = RegisterAuditFields | DeregisterAuditFields;
+
+function emitControlPlaneAudit(fields: ControlPlaneAuditFields): void {
   try {
-    logAuditEntry({
-      timestamp: new Date().toISOString(),
-      tool: "",
-      args: {},
-      status: entry.status ?? "allowed",
-      flags: [],
-      direction: "control-plane",
-      ...(entry.action !== undefined ? { action: entry.action } : {}),
-      ...(entry.sessionId !== undefined ? { sessionId: entry.sessionId } : {}),
-      ...(entry.agentType !== undefined ? { agentType: entry.agentType } : {}),
-      ...(entry.remoteAddress !== undefined ? { remoteAddress: entry.remoteAddress } : {}),
-      ...(entry.remotePort !== undefined ? { remotePort: entry.remotePort } : {}),
-      ...(entry.allowedToolsCount !== undefined ? { allowedToolsCount: entry.allowedToolsCount } : {}),
-    });
+    if (fields.action === "register") {
+      logAuditEntry({
+        timestamp: new Date().toISOString(),
+        tool: "",
+        args: {},
+        status: "allowed",
+        flags: [],
+        direction: "control-plane",
+        action: "register",
+        sessionId: fields.sessionId,
+        agentType: fields.agentType,
+        allowedToolsCount: fields.allowedToolsCount,
+        remoteAddress: fields.remoteAddress,
+        remotePort: fields.remotePort,
+      });
+    } else {
+      logAuditEntry({
+        timestamp: new Date().toISOString(),
+        tool: "",
+        args: {},
+        status: "allowed",
+        flags: [],
+        direction: "control-plane",
+        action: "deregister",
+        sessionId: fields.sessionId,
+        remoteAddress: fields.remoteAddress,
+        remotePort: fields.remotePort,
+      });
+    }
   } catch (err) {
     // Audit-log failures must never break the request path (#C5).
     log.warn({ err }, "control-plane audit write failed (ignored)");
   }
 }
 
-function validateRegisterPayload(body: unknown): { ok: true; value: RegisterPayload } | { ok: false; error: string } {
+function parseRegisterPayload(body: unknown): { ok: true; value: RegisterPayload } | { ok: false; error: string } {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     return { ok: false, error: "Body must be a JSON object" };
   }
   const obj = body as Record<string, unknown>;
-  const sessionId = obj.sessionId;
-  if (typeof sessionId !== "string" || sessionId.length === 0 || sessionId.length > SESSION_ID_MAX_LEN || !SESSION_ID_PATTERN.test(sessionId)) {
-    return { ok: false, error: `Invalid sessionId — must be 1..${SESSION_ID_MAX_LEN} chars matching [A-Za-z0-9._-]+` };
-  }
-  const agentType = obj.agentType;
-  if (typeof agentType !== "string" || agentType.length === 0 || agentType.length > AGENT_TYPE_MAX_LEN || !AGENT_TYPE_PATTERN.test(agentType)) {
-    return { ok: false, error: `Invalid agentType — must be 1..${AGENT_TYPE_MAX_LEN} chars matching [A-Za-z0-9._-]+` };
-  }
-  const allowedTools = obj.allowedTools;
-  if (!Array.isArray(allowedTools)) {
-    return { ok: false, error: "Invalid allowedTools — must be an array" };
-  }
-  if (allowedTools.length === 0) {
-    return { ok: false, error: "Invalid allowedTools — must be a non-empty array" };
-  }
-  if (allowedTools.length > ALLOWLIST_MAX_ENTRIES) {
-    return { ok: false, error: `Invalid allowedTools — too many entries (max ${ALLOWLIST_MAX_ENTRIES})` };
-  }
-  for (const t of allowedTools) {
-    if (typeof t !== "string" || t.length === 0 || t.length > ALLOWLIST_PATTERN_MAX_LEN) {
-      return { ok: false, error: "Invalid allowedTools — every entry must be a non-empty string within length bounds" };
-    }
-    if (!ALLOWLIST_PATTERN_CHARSET.test(t)) {
-      return {
-        ok: false,
-        error: "Invalid allowedTools — entries must match [A-Za-z0-9._*-]+ (no whitespace, control chars, null bytes, or unicode)",
-      };
-    }
-    // Reject bare catch-alls. Per-session allowlists exist to enforce
-    // least-privilege per agent; a bare "*" / "**" pattern grants unrestricted
-    // tool access and supersedes any narrower global ALLOWED_TOOLS list,
-    // which is the opposite of the control plane's purpose. Operators who
-    // want catch-all behaviour should rely on the global allowlist; the
-    // per-session surface accepts only specific names or prefix wildcards
-    // (e.g. "echo__*"). This is consistent with allowlist.ts:matchesPattern,
-    // which already rejects "**" without a non-empty prefix.
-    if (t === "*" || /^\*+$/.test(t)) {
-      return {
-        ok: false,
-        error: `Invalid allowedTools — bare catch-all "${t}" is not allowed in per-session allowlists. Use specific tool names or prefix wildcards (e.g. "echo__*").`,
-      };
-    }
-  }
-  return { ok: true, value: { sessionId, agentType, allowedTools: allowedTools as string[] } };
+  // Single source of truth for the contract (`validateSessionInput` in
+  // session-registry.ts) — same rules apply whether the registration arrives
+  // over HTTP or via a future in-process caller.
+  const validation = validateSessionInput({
+    sessionId: obj.sessionId,
+    agentType: obj.agentType,
+    allowedTools: obj.allowedTools,
+  });
+  if (!validation.ok) return validation;
+  return {
+    ok: true,
+    value: {
+      sessionId: obj.sessionId as string,
+      agentType: obj.agentType as string,
+      allowedTools: obj.allowedTools as string[],
+    },
+  };
 }
 
 function remoteIdentity(req: Request): { remoteAddress: string; remotePort: number } {
@@ -197,16 +202,16 @@ export function createControlPlaneServer(config: ControlPlaneServerConfig): Expr
   app.use(authMiddleware);
 
   app.post("/sessions", (req: Request, res: Response) => {
-    const validation = validateRegisterPayload(req.body);
-    if (!validation.ok) {
+    const parsed = parseRegisterPayload(req.body);
+    if (!parsed.ok) {
       log.warn(
-        { ...remoteIdentity(req), reason: "validation", detail: validation.error },
+        { ...remoteIdentity(req), reason: "validation", detail: parsed.error },
         "control-plane register rejected"
       );
-      res.status(400).json({ error: validation.error });
+      res.status(400).json({ error: parsed.error });
       return;
     }
-    const { sessionId, agentType, allowedTools } = validation.value;
+    const { sessionId, agentType, allowedTools } = parsed.value;
     try {
       config.registry.register({
         sessionId,
@@ -243,12 +248,24 @@ export function createControlPlaneServer(config: ControlPlaneServerConfig): Expr
       res.status(400).json({ error: "Invalid sessionId in path" });
       return;
     }
-    config.registry.deregister(sessionId);
-    emitControlPlaneAudit({
-      action: "deregister",
-      sessionId,
-      ...remoteIdentity(req),
-    });
+    const removed = config.registry.deregister(sessionId);
+    if (removed) {
+      // Audit only on actual state change. A no-op DELETE (session id not
+      // present) is a bug signal (operator thinks the session existed) but
+      // not a real state mutation — recording it would let a buggy CLI in
+      // a retry loop flood the audit NDJSON, mirroring the 401/400 probe-
+      // flood rationale. Warn-log so operators see the mismatch.
+      emitControlPlaneAudit({
+        action: "deregister",
+        sessionId,
+        ...remoteIdentity(req),
+      });
+    } else {
+      log.warn(
+        { ...remoteIdentity(req), sessionId, reason: "session_not_found" },
+        "control-plane deregister: session not found (no-op, idempotent 204)"
+      );
+    }
     res.status(204).end();
   });
 

--- a/src/orchestrator/control-plane.ts
+++ b/src/orchestrator/control-plane.ts
@@ -38,6 +38,17 @@ const log = childLogger("control-plane");
 
 const SESSION_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
 const AGENT_TYPE_PATTERN = /^[A-Za-z0-9._-]+$/;
+/**
+ * Charset for allowedTools entries. Adds `*` (wildcard) on top of the
+ * sessionId/agentType charset since matchesPattern() supports prefix-suffix
+ * wildcards. Rejecting other characters closes a class of injection
+ * vectors — null bytes, newlines, zero-width unicode (U+200B/FEFF/200D),
+ * control characters — that would otherwise round-trip through any future
+ * code path that logs or serialises pattern values. Today only the count
+ * is recorded in audit, but this charset is the contract for future
+ * surfaces (e.g. richer audit logging, MC display).
+ */
+const ALLOWLIST_PATTERN_CHARSET = /^[A-Za-z0-9._*-]+$/;
 const SESSION_ID_MAX_LEN = 128;
 const AGENT_TYPE_MAX_LEN = 32;
 const ALLOWLIST_PATTERN_MAX_LEN = 256;
@@ -113,6 +124,12 @@ function validateRegisterPayload(body: unknown): { ok: true; value: RegisterPayl
   for (const t of allowedTools) {
     if (typeof t !== "string" || t.length === 0 || t.length > ALLOWLIST_PATTERN_MAX_LEN) {
       return { ok: false, error: "Invalid allowedTools — every entry must be a non-empty string within length bounds" };
+    }
+    if (!ALLOWLIST_PATTERN_CHARSET.test(t)) {
+      return {
+        ok: false,
+        error: "Invalid allowedTools — entries must match [A-Za-z0-9._*-]+ (no whitespace, control chars, null bytes, or unicode)",
+      };
     }
     // Reject bare catch-alls. Per-session allowlists exist to enforce
     // least-privilege per agent; a bare "*" / "**" pattern grants unrestricted
@@ -244,6 +261,14 @@ export function createControlPlaneServer(config: ControlPlaneServerConfig): Expr
       registeredAt: entry.registeredAt,
     }));
     res.json(list);
+  });
+
+  // JSON 404 catch-all. Express's default 404 returns HTML that reflects the
+  // requested path in the response body. The control-plane API is otherwise
+  // JSON throughout, so an authenticated probe to an undefined route should
+  // get a JSON error instead of an HTML page that echoes path content.
+  app.use((_req: Request, res: Response) => {
+    res.status(404).json({ error: "Not found" });
   });
 
   // Global error handler — never let an unhandled error leak the token (the

--- a/src/orchestrator/control-plane.ts
+++ b/src/orchestrator/control-plane.ts
@@ -114,6 +114,20 @@ function validateRegisterPayload(body: unknown): { ok: true; value: RegisterPayl
     if (typeof t !== "string" || t.length === 0 || t.length > ALLOWLIST_PATTERN_MAX_LEN) {
       return { ok: false, error: "Invalid allowedTools — every entry must be a non-empty string within length bounds" };
     }
+    // Reject bare catch-alls. Per-session allowlists exist to enforce
+    // least-privilege per agent; a bare "*" / "**" pattern grants unrestricted
+    // tool access and supersedes any narrower global ALLOWED_TOOLS list,
+    // which is the opposite of the control plane's purpose. Operators who
+    // want catch-all behaviour should rely on the global allowlist; the
+    // per-session surface accepts only specific names or prefix wildcards
+    // (e.g. "echo__*"). This is consistent with allowlist.ts:matchesPattern,
+    // which already rejects "**" without a non-empty prefix.
+    if (t === "*" || /^\*+$/.test(t)) {
+      return {
+        ok: false,
+        error: `Invalid allowedTools — bare catch-all "${t}" is not allowed in per-session allowlists. Use specific tool names or prefix wildcards (e.g. "echo__*").`,
+      };
+    }
   }
   return { ok: true, value: { sessionId, agentType, allowedTools: allowedTools as string[] } };
 }

--- a/src/orchestrator/control-plane.ts
+++ b/src/orchestrator/control-plane.ts
@@ -1,0 +1,246 @@
+import express, { type Express, type Request, type Response, type NextFunction } from "express";
+import { timingSafeEqual } from "node:crypto";
+import { childLogger } from "../logger.js";
+import { logAuditEntry, type AuditEntry } from "../mcp-proxy/logger.js";
+import type { SessionRegistry } from "./session-registry.js";
+
+const log = childLogger("control-plane");
+
+/**
+ * Tier 1.3 (#56) — control-plane HTTP server.
+ *
+ * Exposes register / deregister / list endpoints for the session registry.
+ * Designed to be reachable ONLY from host-side processes (the dispatch CLI /
+ * Mission Control connector). Two layers of defence:
+ *
+ *   1. Loopback bind on 127.0.0.1:18924 — set in `src/index.ts`, NOT here.
+ *      Sandboxes cannot reach the host's loopback interface; they reach the
+ *      host's Docker bridge IP via `host.docker.internal`. Hard-coded literal
+ *      so an operator cannot widen it via env (decision #3 in the plan).
+ *   2. Bearer-token gate via `MCP_CONTROL_TOKEN` on every endpoint except
+ *      `/health`. Constant-time comparison via `crypto.timingSafeEqual`, with
+ *      explicit length check first (timingSafeEqual throws on length mismatch).
+ *      Length-mismatch is treated as a wrong token (401), not a 400.
+ *
+ * Audit-log invariants:
+ *   - Successful POST/DELETE write a single audit entry with
+ *     `direction: "control-plane"` and structured fields capturing the action,
+ *     session id, agent type, source remote addr/port, and allowed-tools COUNT.
+ *     Tool names themselves are NEVER recorded (operator-private allowlist).
+ *   - 401 / 400 rejections do NOT write audit entries — only warn-log — to
+ *     prevent a probe burst from flooding the NDJSON file.
+ *   - Token value never appears in any log line, audit entry, or response.
+ *
+ * Input-validation invariants for register: same charset/length envelope as
+ * the identity-header parser (#52) so Prometheus / OTEL / NDJSON consumers
+ * all see consistently bounded values.
+ */
+
+const SESSION_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+const AGENT_TYPE_PATTERN = /^[A-Za-z0-9._-]+$/;
+const SESSION_ID_MAX_LEN = 128;
+const AGENT_TYPE_MAX_LEN = 32;
+const ALLOWLIST_PATTERN_MAX_LEN = 256;
+const ALLOWLIST_MAX_ENTRIES = 256;
+
+export interface ControlPlaneServerConfig {
+  readonly registry: SessionRegistry;
+  readonly token: string;
+}
+
+interface RegisterPayload {
+  sessionId: string;
+  agentType: string;
+  allowedTools: string[];
+}
+
+function tokenMatches(provided: string, expected: string): boolean {
+  if (provided.length !== expected.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}
+
+function emitControlPlaneAudit(entry: Omit<AuditEntry, "timestamp" | "tool" | "args" | "flags" | "status"> & {
+  readonly status?: AuditEntry["status"];
+}): void {
+  try {
+    logAuditEntry({
+      timestamp: new Date().toISOString(),
+      tool: "",
+      args: {},
+      status: entry.status ?? "allowed",
+      flags: [],
+      direction: "control-plane",
+      ...(entry.action !== undefined ? { action: entry.action } : {}),
+      ...(entry.sessionId !== undefined ? { sessionId: entry.sessionId } : {}),
+      ...(entry.agentType !== undefined ? { agentType: entry.agentType } : {}),
+      ...(entry.remoteAddress !== undefined ? { remoteAddress: entry.remoteAddress } : {}),
+      ...(entry.remotePort !== undefined ? { remotePort: entry.remotePort } : {}),
+      ...(entry.allowedToolsCount !== undefined ? { allowedToolsCount: entry.allowedToolsCount } : {}),
+    });
+  } catch (err) {
+    // Audit-log failures must never break the request path (#C5).
+    log.warn({ err }, "control-plane audit write failed (ignored)");
+  }
+}
+
+function validateRegisterPayload(body: unknown): { ok: true; value: RegisterPayload } | { ok: false; error: string } {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, error: "Body must be a JSON object" };
+  }
+  const obj = body as Record<string, unknown>;
+  const sessionId = obj.sessionId;
+  if (typeof sessionId !== "string" || sessionId.length === 0 || sessionId.length > SESSION_ID_MAX_LEN || !SESSION_ID_PATTERN.test(sessionId)) {
+    return { ok: false, error: `Invalid sessionId — must be 1..${SESSION_ID_MAX_LEN} chars matching [A-Za-z0-9._-]+` };
+  }
+  const agentType = obj.agentType;
+  if (typeof agentType !== "string" || agentType.length === 0 || agentType.length > AGENT_TYPE_MAX_LEN || !AGENT_TYPE_PATTERN.test(agentType)) {
+    return { ok: false, error: `Invalid agentType — must be 1..${AGENT_TYPE_MAX_LEN} chars matching [A-Za-z0-9._-]+` };
+  }
+  const allowedTools = obj.allowedTools;
+  if (!Array.isArray(allowedTools)) {
+    return { ok: false, error: "Invalid allowedTools — must be an array" };
+  }
+  if (allowedTools.length === 0) {
+    return { ok: false, error: "Invalid allowedTools — must be a non-empty array" };
+  }
+  if (allowedTools.length > ALLOWLIST_MAX_ENTRIES) {
+    return { ok: false, error: `Invalid allowedTools — too many entries (max ${ALLOWLIST_MAX_ENTRIES})` };
+  }
+  for (const t of allowedTools) {
+    if (typeof t !== "string" || t.length === 0 || t.length > ALLOWLIST_PATTERN_MAX_LEN) {
+      return { ok: false, error: "Invalid allowedTools — every entry must be a non-empty string within length bounds" };
+    }
+  }
+  return { ok: true, value: { sessionId, agentType, allowedTools: allowedTools as string[] } };
+}
+
+function remoteIdentity(req: Request): { remoteAddress: string; remotePort: number } {
+  const sock = req.socket;
+  return {
+    remoteAddress: sock?.remoteAddress ?? "",
+    remotePort: sock?.remotePort ?? 0,
+  };
+}
+
+export function createControlPlaneServer(config: ControlPlaneServerConfig): Express {
+  const app = express();
+  app.use(express.json({ limit: "64kb" }));
+
+  // Bearer-token middleware — applied to every /sessions* route. /health
+  // (declared above this middleware below) is exempt by route registration
+  // order and by an explicit guard in the middleware itself.
+  function authMiddleware(req: Request, res: Response, next: NextFunction): void {
+    if (req.path === "/health") {
+      next();
+      return;
+    }
+    const auth = req.header("authorization");
+    if (!auth || !auth.startsWith("Bearer ")) {
+      log.warn(
+        { ...remoteIdentity(req), path: req.path, method: req.method, reason: "missing_or_malformed_authorization" },
+        "control-plane request rejected"
+      );
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    const provided = auth.slice("Bearer ".length);
+    if (!tokenMatches(provided, config.token)) {
+      log.warn(
+        { ...remoteIdentity(req), path: req.path, method: req.method, reason: "wrong_token" },
+        "control-plane request rejected"
+      );
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    next();
+  }
+
+  app.get("/health", (_req: Request, res: Response) => {
+    res.json({ status: "ok" });
+  });
+
+  app.use(authMiddleware);
+
+  app.post("/sessions", (req: Request, res: Response) => {
+    const validation = validateRegisterPayload(req.body);
+    if (!validation.ok) {
+      log.warn(
+        { ...remoteIdentity(req), reason: "validation", detail: validation.error },
+        "control-plane register rejected"
+      );
+      res.status(400).json({ error: validation.error });
+      return;
+    }
+    const { sessionId, agentType, allowedTools } = validation.value;
+    try {
+      config.registry.register({
+        sessionId,
+        agentType,
+        allowlist: { patterns: allowedTools },
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { ...remoteIdentity(req), reason: "registry_rejected", detail: message },
+        "control-plane register rejected by registry"
+      );
+      res.status(400).json({ error: message });
+      return;
+    }
+    emitControlPlaneAudit({
+      action: "register",
+      sessionId,
+      agentType,
+      allowedToolsCount: allowedTools.length,
+      ...remoteIdentity(req),
+    });
+    res.status(201).json({ sessionId });
+  });
+
+  app.delete("/sessions/:sessionId", (req: Request, res: Response) => {
+    const rawSessionId = req.params.sessionId;
+    const sessionId = typeof rawSessionId === "string" ? rawSessionId : "";
+    if (!sessionId || sessionId.length > SESSION_ID_MAX_LEN || !SESSION_ID_PATTERN.test(sessionId)) {
+      log.warn(
+        { ...remoteIdentity(req), reason: "invalid_session_id" },
+        "control-plane deregister rejected — invalid session id in path"
+      );
+      res.status(400).json({ error: "Invalid sessionId in path" });
+      return;
+    }
+    config.registry.deregister(sessionId);
+    emitControlPlaneAudit({
+      action: "deregister",
+      sessionId,
+      ...remoteIdentity(req),
+    });
+    res.status(204).end();
+  });
+
+  app.get("/sessions", (_req: Request, res: Response) => {
+    // Operator-private allowlist contents NEVER leave the registry. Only the
+    // session id, agent type, and registration timestamp are returned.
+    const list = config.registry.list().map((entry) => ({
+      sessionId: entry.sessionId,
+      agentType: entry.agentType,
+      registeredAt: entry.registeredAt,
+    }));
+    res.json(list);
+  });
+
+  // Global error handler — never let an unhandled error leak the token (the
+  // bearer-token middleware would already have stripped it from req, but
+  // belt-and-braces for any future error path that touches authorization).
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    log.error({ error: err.message }, "control-plane unhandled error");
+    if (!res.headersSent) {
+      res.status(500).json({ error: "Internal control-plane error" });
+    }
+  });
+
+  return app;
+}

--- a/src/orchestrator/session-registry.ts
+++ b/src/orchestrator/session-registry.ts
@@ -3,6 +3,14 @@ import type { AllowlistConfig } from "../mcp-proxy/allowlist.js";
 
 const log = childLogger("session-registry");
 
+/**
+ * Cap on concurrent registrations. Defense-in-depth: even with the bearer
+ * token, a buggy or compromised host-side caller in a tight loop should not
+ * exhaust process memory. 1024 is well above any realistic single-host
+ * orchestrator footprint and well below any Map size that risks GC pressure.
+ */
+export const MAX_SESSIONS = 1024;
+
 export interface SessionRegistryEntry {
   readonly sessionId: string;
   readonly agentType: string;
@@ -40,6 +48,24 @@ function validate(params: RegisterParams): void {
 }
 
 /**
+ * Return a deep-enough copy of an entry that callers cannot mutate the
+ * registry's internal state via the returned reference. The `readonly`
+ * annotations on `SessionRegistryEntry` are compile-time only — a caller
+ * could `(entry.allowlist.patterns as string[]).push("*")` without this
+ * defensive copy and silently widen every future allowlist check. Copies
+ * the patterns array (the only mutable member); strings and the date string
+ * are immutable by JS semantics.
+ */
+function cloneEntry(entry: SessionRegistryEntry): SessionRegistryEntry {
+  return {
+    sessionId: entry.sessionId,
+    agentType: entry.agentType,
+    allowlist: { patterns: [...entry.allowlist.patterns] },
+    registeredAt: entry.registeredAt,
+  };
+}
+
+/**
  * In-memory, in-process registry of per-session allowlists. Constructed once at
  * startup and shared by reference between the proxy server (read-only — looks
  * up entries on the request hot path) and the control-plane server (writer —
@@ -63,6 +89,12 @@ export function createSessionRegistry(): SessionRegistry {
           { sessionId: params.sessionId, previousAgentType: existing.agentType, newAgentType: params.agentType },
           "session re-register — overwriting prior entry (likely dispatch-CLI bug or restart race)"
         );
+      } else if (entries.size >= MAX_SESSIONS) {
+        // Capacity check only when the call is a fresh registration, not an
+        // overwrite — a re-register is bounded by the existing slot count.
+        throw new Error(
+          `Session registry is full (max ${MAX_SESSIONS} concurrent sessions). Deregister stale entries before registering new ones.`
+        );
       }
       entries.set(params.sessionId, {
         sessionId: params.sessionId,
@@ -75,10 +107,11 @@ export function createSessionRegistry(): SessionRegistry {
       entries.delete(sessionId);
     },
     lookup(sessionId) {
-      return entries.get(sessionId);
+      const entry = entries.get(sessionId);
+      return entry ? cloneEntry(entry) : undefined;
     },
     list() {
-      return [...entries.values()];
+      return [...entries.values()].map(cloneEntry);
     },
     size() {
       return entries.size;

--- a/src/orchestrator/session-registry.ts
+++ b/src/orchestrator/session-registry.ts
@@ -1,0 +1,87 @@
+import { childLogger } from "../logger.js";
+import type { AllowlistConfig } from "../mcp-proxy/allowlist.js";
+
+const log = childLogger("session-registry");
+
+export interface SessionRegistryEntry {
+  readonly sessionId: string;
+  readonly agentType: string;
+  readonly allowlist: AllowlistConfig;
+  readonly registeredAt: string;
+}
+
+export interface RegisterParams {
+  readonly sessionId: string;
+  readonly agentType: string;
+  readonly allowlist: AllowlistConfig;
+}
+
+export interface SessionRegistry {
+  register(params: RegisterParams): void;
+  deregister(sessionId: string): void;
+  lookup(sessionId: string): SessionRegistryEntry | undefined;
+  list(): SessionRegistryEntry[];
+  size(): number;
+}
+
+function validate(params: RegisterParams): void {
+  if (typeof params.sessionId !== "string" || params.sessionId.length === 0) {
+    throw new Error("Invalid sessionId — must be a non-empty string");
+  }
+  if (typeof params.agentType !== "string" || params.agentType.length === 0) {
+    throw new Error("Invalid agentType — must be a non-empty string");
+  }
+  if (!params.allowlist || !Array.isArray(params.allowlist.patterns)) {
+    throw new Error("Invalid allowlist — patterns must be an array");
+  }
+  if (params.allowlist.patterns.length === 0) {
+    throw new Error("Invalid allowlist — patterns must be a non-empty array");
+  }
+}
+
+/**
+ * In-memory, in-process registry of per-session allowlists. Constructed once at
+ * startup and shared by reference between the proxy server (read-only — looks
+ * up entries on the request hot path) and the control-plane server (writer —
+ * mutates via register/deregister). No persistence: a process restart loses
+ * registrations, and the dispatch CLI is responsible for re-registering.
+ *
+ * Defensive input validation lives both here and at the HTTP layer; the HTTP
+ * layer rejects with structured 400 responses, this layer throws so a buggy
+ * in-process caller surfaces the bug at its call site rather than silently
+ * registering something invalid.
+ */
+export function createSessionRegistry(): SessionRegistry {
+  const entries = new Map<string, SessionRegistryEntry>();
+
+  return {
+    register(params) {
+      validate(params);
+      const existing = entries.get(params.sessionId);
+      if (existing) {
+        log.warn(
+          { sessionId: params.sessionId, previousAgentType: existing.agentType, newAgentType: params.agentType },
+          "session re-register — overwriting prior entry (likely dispatch-CLI bug or restart race)"
+        );
+      }
+      entries.set(params.sessionId, {
+        sessionId: params.sessionId,
+        agentType: params.agentType,
+        allowlist: { patterns: [...params.allowlist.patterns] },
+        registeredAt: new Date().toISOString(),
+      });
+    },
+    deregister(sessionId) {
+      entries.delete(sessionId);
+    },
+    lookup(sessionId) {
+      return entries.get(sessionId);
+    },
+    list() {
+      return [...entries.values()];
+    },
+    size() {
+      return entries.size;
+    },
+  };
+}

--- a/src/orchestrator/session-registry.ts
+++ b/src/orchestrator/session-registry.ts
@@ -11,6 +11,90 @@ const log = childLogger("session-registry");
  */
 export const MAX_SESSIONS = 1024;
 
+/**
+ * Shared validation contract for control-plane register payloads. The registry
+ * (this module) and the HTTP layer (`src/orchestrator/control-plane.ts`) both
+ * call `validateSessionInput` so there is exactly one source of truth for what
+ * counts as a well-formed input. The HTTP layer returns the structured error
+ * as a 400 response body; the registry throws so an in-process caller bypassing
+ * HTTP still gets the same contract.
+ *
+ * Charset / length envelopes intentionally match the identity-header parser
+ * (#52) so Prometheus / OTEL / NDJSON consumers see consistently bounded
+ * values across all surfaces.
+ */
+export const SESSION_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+export const AGENT_TYPE_PATTERN = /^[A-Za-z0-9._-]+$/;
+export const ALLOWLIST_PATTERN_CHARSET = /^[A-Za-z0-9._*-]+$/;
+export const SESSION_ID_MAX_LEN = 128;
+export const AGENT_TYPE_MAX_LEN = 32;
+export const ALLOWLIST_PATTERN_MAX_LEN = 256;
+export const ALLOWLIST_MAX_ENTRIES = 256;
+
+export type ValidationResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly error: string };
+
+export function validateSessionInput(input: {
+  readonly sessionId: unknown;
+  readonly agentType: unknown;
+  readonly allowedTools: unknown;
+}): ValidationResult {
+  const { sessionId, agentType, allowedTools } = input;
+  if (
+    typeof sessionId !== "string" ||
+    sessionId.length === 0 ||
+    sessionId.length > SESSION_ID_MAX_LEN ||
+    !SESSION_ID_PATTERN.test(sessionId)
+  ) {
+    return {
+      ok: false,
+      error: `Invalid sessionId — must be 1..${SESSION_ID_MAX_LEN} chars matching [A-Za-z0-9._-]+`,
+    };
+  }
+  if (
+    typeof agentType !== "string" ||
+    agentType.length === 0 ||
+    agentType.length > AGENT_TYPE_MAX_LEN ||
+    !AGENT_TYPE_PATTERN.test(agentType)
+  ) {
+    return {
+      ok: false,
+      error: `Invalid agentType — must be 1..${AGENT_TYPE_MAX_LEN} chars matching [A-Za-z0-9._-]+`,
+    };
+  }
+  if (!Array.isArray(allowedTools)) {
+    return { ok: false, error: "Invalid allowedTools — must be an array" };
+  }
+  if (allowedTools.length === 0) {
+    return { ok: false, error: "Invalid allowedTools — must be a non-empty array" };
+  }
+  if (allowedTools.length > ALLOWLIST_MAX_ENTRIES) {
+    return { ok: false, error: `Invalid allowedTools — too many entries (max ${ALLOWLIST_MAX_ENTRIES})` };
+  }
+  for (const t of allowedTools) {
+    if (typeof t !== "string" || t.length === 0 || t.length > ALLOWLIST_PATTERN_MAX_LEN) {
+      return {
+        ok: false,
+        error: "Invalid allowedTools — every entry must be a non-empty string within length bounds",
+      };
+    }
+    if (!ALLOWLIST_PATTERN_CHARSET.test(t)) {
+      return {
+        ok: false,
+        error: "Invalid allowedTools — entries must match [A-Za-z0-9._*-]+ (no whitespace, control chars, null bytes, or unicode)",
+      };
+    }
+    if (t === "*" || /^\*+$/.test(t)) {
+      return {
+        ok: false,
+        error: `Invalid allowedTools — bare catch-all "${t}" is not allowed in per-session allowlists. Use specific tool names or prefix wildcards (e.g. "echo__*").`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
 export interface SessionRegistryEntry {
   readonly sessionId: string;
   readonly agentType: string;
@@ -26,24 +110,26 @@ export interface RegisterParams {
 
 export interface SessionRegistry {
   register(params: RegisterParams): void;
-  deregister(sessionId: string): void;
+  /**
+   * Remove the session and return whether something was actually removed.
+   * Callers (e.g. the control-plane DELETE handler) use the return value to
+   * decide whether the deregistration was a real state change worth auditing
+   * or a no-op worth warn-logging only.
+   */
+  deregister(sessionId: string): boolean;
   lookup(sessionId: string): SessionRegistryEntry | undefined;
   list(): SessionRegistryEntry[];
   size(): number;
 }
 
 function validate(params: RegisterParams): void {
-  if (typeof params.sessionId !== "string" || params.sessionId.length === 0) {
-    throw new Error("Invalid sessionId — must be a non-empty string");
-  }
-  if (typeof params.agentType !== "string" || params.agentType.length === 0) {
-    throw new Error("Invalid agentType — must be a non-empty string");
-  }
-  if (!params.allowlist || !Array.isArray(params.allowlist.patterns)) {
-    throw new Error("Invalid allowlist — patterns must be an array");
-  }
-  if (params.allowlist.patterns.length === 0) {
-    throw new Error("Invalid allowlist — patterns must be a non-empty array");
+  const result = validateSessionInput({
+    sessionId: params.sessionId,
+    agentType: params.agentType,
+    allowedTools: params.allowlist?.patterns,
+  });
+  if (!result.ok) {
+    throw new Error(result.error);
   }
 }
 
@@ -104,7 +190,7 @@ export function createSessionRegistry(): SessionRegistry {
       });
     },
     deregister(sessionId) {
-      entries.delete(sessionId);
+      return entries.delete(sessionId);
     },
     lookup(sessionId) {
       const entry = entries.get(sessionId);

--- a/tests/orchestrator/control-plane.test.ts
+++ b/tests/orchestrator/control-plane.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+
+/**
+ * Tier 1.3 — control-plane HTTP server tests.
+ *
+ * The control plane is a NEW HTTP attack surface (loopback bind on
+ * 127.0.0.1:18924, bearer-token gated). The following invariants are
+ * security-critical and locked in by these tests:
+ *
+ *   - Bearer-token gate on every endpoint except /health.
+ *   - Wrong-length token returns 401, not 400 (timing-safe-equal length probe).
+ *   - 401/400 responses do NOT write audit entries (probe flood guard).
+ *   - GET /sessions never returns the allowlist contents.
+ *   - Bind literal "127.0.0.1" lives in source — no MCP_CONTROL_BIND env knob.
+ *   - Token value never appears in any captured log line or audit entry.
+ */
+
+const { mockLogger, auditEntries } = vi.hoisted(() => {
+  const mockLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+  };
+  mockLogger.child.mockReturnValue(mockLogger);
+  const auditEntries: unknown[] = [];
+  return { mockLogger, auditEntries };
+});
+vi.mock("../../src/logger.js", () => ({
+  default: mockLogger,
+  childLogger: vi.fn(() => mockLogger),
+}));
+vi.mock("../../src/mcp-proxy/logger.js", async () => {
+  const actual = await vi.importActual<typeof import("../../src/mcp-proxy/logger.js")>(
+    "../../src/mcp-proxy/logger.js"
+  );
+  return {
+    ...actual,
+    logAuditEntry: vi.fn((entry: unknown) => {
+      auditEntries.push(entry);
+    }),
+  };
+});
+
+import { createSessionRegistry, type SessionRegistry } from "../../src/orchestrator/session-registry.js";
+import { createControlPlaneServer } from "../../src/orchestrator/control-plane.js";
+import type { AuditEntry } from "../../src/mcp-proxy/logger.js";
+
+const TOKEN = "a".repeat(64);
+
+async function startServer(opts: {
+  registry: SessionRegistry;
+  token?: string;
+}): Promise<{ server: Server; baseUrl: string }> {
+  const app = createControlPlaneServer({
+    registry: opts.registry,
+    token: opts.token ?? TOKEN,
+  });
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const addr = server.address() as AddressInfo;
+  return { server, baseUrl: `http://127.0.0.1:${addr.port}` };
+}
+
+async function closeServer(server: Server | undefined): Promise<void> {
+  if (!server || !server.listening) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+describe("Control-plane HTTP server", () => {
+  let server: Server | undefined;
+  let baseUrl: string;
+  let registry: SessionRegistry;
+
+  beforeEach(async () => {
+    auditEntries.length = 0;
+    mockLogger.warn.mockClear();
+    mockLogger.info.mockClear();
+    registry = createSessionRegistry();
+    const started = await startServer({ registry });
+    server = started.server;
+    baseUrl = started.baseUrl;
+  });
+
+  afterEach(async () => {
+    await closeServer(server);
+    server = undefined;
+  });
+
+  it("POST /sessions without Authorization header → 401", async () => {
+    const res = await fetch(`${baseUrl}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionId: "x", agentType: "reviewer", allowedTools: ["Read"] }),
+    });
+    expect(res.status).toBe(401);
+    expect(registry.size()).toBe(0);
+  });
+
+  it("POST /sessions with malformed Authorization header (no Bearer prefix) → 401", async () => {
+    const res = await fetch(`${baseUrl}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: TOKEN },
+      body: JSON.stringify({ sessionId: "x", agentType: "reviewer", allowedTools: ["Read"] }),
+    });
+    expect(res.status).toBe(401);
+    expect(registry.size()).toBe(0);
+  });
+
+  it("POST /sessions with wrong-but-correct-length token → 401", async () => {
+    const wrong = "b".repeat(64);
+    const res = await fetch(`${baseUrl}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${wrong}` },
+      body: JSON.stringify({ sessionId: "x", agentType: "reviewer", allowedTools: ["Read"] }),
+    });
+    expect(res.status).toBe(401);
+    expect(registry.size()).toBe(0);
+  });
+
+  it("POST /sessions with wrong-length token → 401 (NOT 400 — proves timingSafeEqual length-mismatch path)", async () => {
+    const tooShort = "a".repeat(10);
+    const tooLong = "a".repeat(200);
+    for (const bad of [tooShort, tooLong]) {
+      const res = await fetch(`${baseUrl}/sessions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${bad}` },
+        body: JSON.stringify({ sessionId: "x", agentType: "reviewer", allowedTools: ["Read"] }),
+      });
+      expect(res.status).toBe(401);
+    }
+    expect(registry.size()).toBe(0);
+  });
+
+  it("POST /sessions with valid token + valid body → 201, registry has entry", async () => {
+    const res = await fetch(`${baseUrl}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({ sessionId: "abc", agentType: "reviewer", allowedTools: ["Read", "Grep"] }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json() as { sessionId: string };
+    expect(body.sessionId).toBe("abc");
+    expect(registry.size()).toBe(1);
+    const entry = registry.lookup("abc");
+    expect(entry?.agentType).toBe("reviewer");
+    expect(entry?.allowlist.patterns).toEqual(["Read", "Grep"]);
+  });
+
+  it("POST /sessions with malformed body → 400 with structured error and registry unchanged", async () => {
+    const cases: Array<Record<string, unknown>> = [
+      { agentType: "reviewer", allowedTools: ["Read"] }, // missing sessionId
+      { sessionId: "ok", allowedTools: ["Read"] }, // missing agentType
+      { sessionId: "ok", agentType: "reviewer" }, // missing allowedTools
+      { sessionId: "ok", agentType: "reviewer", allowedTools: "Read" }, // non-array allowedTools
+      { sessionId: "bad value!", agentType: "reviewer", allowedTools: ["Read"] }, // charset violation
+      { sessionId: "a".repeat(200), agentType: "reviewer", allowedTools: ["Read"] }, // length violation
+      { sessionId: "ok", agentType: "x".repeat(50), allowedTools: ["Read"] }, // agentType too long
+      { sessionId: "ok", agentType: "reviewer", allowedTools: [] }, // empty allowedTools
+    ];
+    for (const body of cases) {
+      const res = await fetch(`${baseUrl}/sessions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
+        body: JSON.stringify(body),
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json() as { error: string };
+      expect(typeof json.error).toBe("string");
+      expect(json.error.length).toBeGreaterThan(0);
+    }
+    expect(registry.size()).toBe(0);
+  });
+
+  it("DELETE /sessions/:id with valid token + existing id → 204, registry empty", async () => {
+    registry.register({ sessionId: "delme", agentType: "reviewer", allowlist: { patterns: ["Read"] } });
+    expect(registry.size()).toBe(1);
+    const res = await fetch(`${baseUrl}/sessions/delme`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(204);
+    expect(registry.size()).toBe(0);
+  });
+
+  it("DELETE /sessions/:id with valid token + unknown id → 204 (idempotent)", async () => {
+    const res = await fetch(`${baseUrl}/sessions/never-was`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(204);
+  });
+
+  it("DELETE /sessions/:id without Authorization → 401", async () => {
+    registry.register({ sessionId: "stay", agentType: "reviewer", allowlist: { patterns: ["Read"] } });
+    const res = await fetch(`${baseUrl}/sessions/stay`, { method: "DELETE" });
+    expect(res.status).toBe(401);
+    expect(registry.size()).toBe(1);
+  });
+
+  it("GET /sessions with valid token returns array of {sessionId, agentType, registeredAt} — NOT allowedTools", async () => {
+    registry.register({ sessionId: "g1", agentType: "reviewer", allowlist: { patterns: ["Read"] } });
+    registry.register({ sessionId: "g2", agentType: "coder", allowlist: { patterns: ["Write"] } });
+    const res = await fetch(`${baseUrl}/sessions`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Array<Record<string, unknown>>;
+    expect(body).toHaveLength(2);
+    for (const entry of body) {
+      expect(typeof entry.sessionId).toBe("string");
+      expect(typeof entry.agentType).toBe("string");
+      expect(typeof entry.registeredAt).toBe("string");
+      expect(entry).not.toHaveProperty("allowedTools");
+      expect(entry).not.toHaveProperty("allowlist");
+      expect(entry).not.toHaveProperty("patterns");
+    }
+  });
+
+  it("GET /sessions without Authorization → 401", async () => {
+    const res = await fetch(`${baseUrl}/sessions`);
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /health is reachable WITHOUT Authorization header → 200", async () => {
+    const res = await fetch(`${baseUrl}/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("ok");
+  });
+
+  it("successful POST /sessions writes an audit entry with direction='control-plane' + structured fields (NOT tool names)", async () => {
+    const res = await fetch(`${baseUrl}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({ sessionId: "audit-1", agentType: "reviewer", allowedTools: ["Read", "Grep", "Write"] }),
+    });
+    expect(res.status).toBe(201);
+    const cpEntries = (auditEntries as AuditEntry[]).filter(
+      (e) => e.direction === "control-plane"
+    );
+    expect(cpEntries).toHaveLength(1);
+    const entry = cpEntries[0]!;
+    expect(entry.action).toBe("register");
+    expect(entry.sessionId).toBe("audit-1");
+    expect(entry.agentType).toBe("reviewer");
+    expect(entry.allowedToolsCount).toBe(3);
+    expect(typeof entry.remoteAddress).toBe("string");
+    expect(typeof entry.remotePort).toBe("number");
+    expect(entry.status).toBe("allowed");
+    // CRITICAL: tool names must NEVER appear in the audit entry
+    const serialized = JSON.stringify(entry);
+    expect(serialized).not.toMatch(/Read|Grep|Write/);
+  });
+
+  it("successful DELETE /sessions/:id writes an audit entry with action='deregister'", async () => {
+    registry.register({ sessionId: "audit-del", agentType: "coder", allowlist: { patterns: ["Read"] } });
+    auditEntries.length = 0; // clear out anything from setup
+    const res = await fetch(`${baseUrl}/sessions/audit-del`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(204);
+    const cpEntries = (auditEntries as AuditEntry[]).filter(
+      (e) => e.direction === "control-plane"
+    );
+    expect(cpEntries).toHaveLength(1);
+    const entry = cpEntries[0]!;
+    expect(entry.action).toBe("deregister");
+    expect(entry.sessionId).toBe("audit-del");
+    expect(typeof entry.remoteAddress).toBe("string");
+    expect(typeof entry.remotePort).toBe("number");
+  });
+
+  it("401 and 400 responses do NOT write audit entries (probe flood guard)", async () => {
+    auditEntries.length = 0;
+    // 401 — wrong token
+    await fetch(`${baseUrl}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${"b".repeat(64)}` },
+      body: JSON.stringify({ sessionId: "x", agentType: "r", allowedTools: ["R"] }),
+    });
+    // 400 — malformed body
+    await fetch(`${baseUrl}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({ broken: true }),
+    });
+    const cpEntries = (auditEntries as AuditEntry[]).filter(
+      (e) => e.direction === "control-plane"
+    );
+    expect(cpEntries).toHaveLength(0);
+  });
+
+  it("token value never appears in any captured log line or audit entry (even on success)", async () => {
+    await fetch(`${baseUrl}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({ sessionId: "secrets", agentType: "reviewer", allowedTools: ["Read"] }),
+    });
+    // Try wrong token too — sometimes token leaks happen on the error path.
+    await fetch(`${baseUrl}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${"b".repeat(64)}` },
+      body: JSON.stringify({ sessionId: "secrets-2", agentType: "reviewer", allowedTools: ["Read"] }),
+    });
+    const allLogCalls = [
+      ...mockLogger.info.mock.calls,
+      ...mockLogger.warn.mock.calls,
+      ...mockLogger.error.mock.calls,
+      ...mockLogger.debug.mock.calls,
+    ];
+    const allLogText = JSON.stringify(allLogCalls);
+    expect(allLogText).not.toContain(TOKEN);
+    const allAuditText = JSON.stringify(auditEntries);
+    expect(allAuditText).not.toContain(TOKEN);
+  });
+});
+
+describe("Control-plane bind config (static source check)", () => {
+  /**
+   * The control-plane bind MUST be a hard-coded "127.0.0.1" literal in
+   * src/index.ts. Configuring the bind via env (e.g. MCP_CONTROL_BIND) is
+   * an explicit anti-feature: an operator could silently widen the bind
+   * (e.g. typo it to 0.0.0.0) and void the primary defence (loopback bind).
+   * This test enforces the source-level invariant — when src/index.ts is
+   * wired in the final step, it must include the literal AND must not read
+   * any MCP_CONTROL_BIND env var.
+   */
+  it("src/index.ts contains the literal '127.0.0.1' for the control-plane bind", () => {
+    const indexPath = path.resolve(__dirname, "../../src/index.ts");
+    const source = readFileSync(indexPath, "utf-8");
+    // The control-plane wiring block (the test enforces presence of the
+    // exact string the runtime must use). Keyed off the file containing
+    // both "MCP_CONTROL_TOKEN" and "127.0.0.1" so we don't false-positive
+    // on the (separate) metrics-server block which already binds 127.0.0.1.
+    expect(source).toMatch(/MCP_CONTROL_TOKEN/);
+    const lines = source.split("\n");
+    const cpBindLine = lines.find(
+      (l) => l.includes("controlPlaneApp") || l.includes("controlPlaneServer")
+    );
+    expect(cpBindLine, "control-plane app.listen call must exist in src/index.ts").toBeDefined();
+    // The block as a whole must reference the literal IP for the control plane.
+    expect(source).toMatch(/127\.0\.0\.1.*control|control.*127\.0\.0\.1/s);
+  });
+
+  it("src/index.ts does NOT read MCP_CONTROL_BIND from env (no env-knob for the bind)", () => {
+    const indexPath = path.resolve(__dirname, "../../src/index.ts");
+    const source = readFileSync(indexPath, "utf-8");
+    expect(source).not.toMatch(/MCP_CONTROL_BIND/);
+  });
+});

--- a/tests/orchestrator/control-plane.test.ts
+++ b/tests/orchestrator/control-plane.test.ts
@@ -226,12 +226,32 @@ describe("Control-plane HTTP server", () => {
     expect(registry.size()).toBe(0);
   });
 
-  it("DELETE /sessions/:id with valid token + unknown id → 204 (idempotent)", async () => {
+  it("DELETE /sessions/:id with valid token + unknown id → 204 (idempotent) and does NOT write audit entry (F6)", async () => {
+    auditEntries.length = 0;
     const res = await fetch(`${baseUrl}/sessions/never-was`, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${TOKEN}` },
     });
     expect(res.status).toBe(204);
+    // F6: no-op DELETE is not a real state change. The probe-flood rationale
+    // applies — a buggy CLI in a retry loop must not flood the NDJSON file.
+    const cpEntries = (auditEntries as AuditEntry[]).filter(
+      (e) => e.direction === "control-plane"
+    );
+    expect(cpEntries).toHaveLength(0);
+  });
+
+  it("DELETE /sessions/:id with path param violating charset → 400 (F10)", async () => {
+    // Path param goes through Express's URL decoder before reaching our
+    // handler. A literal "bad value!" (after %-decoding) fails the
+    // SESSION_ID_PATTERN check and must be rejected with a 400.
+    const res = await fetch(`${baseUrl}/sessions/bad%20value%21`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/sessionId/i);
   });
 
   it("DELETE /sessions/:id without Authorization → 401", async () => {
@@ -372,6 +392,68 @@ describe("Control-plane HTTP server", () => {
     expect(allLogText).not.toContain(TOKEN);
     const allAuditText = JSON.stringify(auditEntries);
     expect(allAuditText).not.toContain(TOKEN);
+  });
+});
+
+describe("Control-plane audit-write failure resilience (F9)", () => {
+  let server: Server | undefined;
+  let baseUrl: string;
+  let registry: SessionRegistry;
+  let logAuditEntryMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    // Re-resolve the mocked logAuditEntry and switch it to throw for this
+    // suite. The audit emitter MUST catch the throw and continue serving so
+    // the control-plane response is unaffected.
+    const loggerModule = await import("../../src/mcp-proxy/logger.js");
+    logAuditEntryMock = loggerModule.logAuditEntry as unknown as ReturnType<typeof vi.fn>;
+    logAuditEntryMock.mockReset();
+    logAuditEntryMock.mockImplementation(() => {
+      throw new Error("simulated audit-log disk full");
+    });
+    mockLogger.warn.mockClear();
+    registry = createSessionRegistry();
+    const started = await startServer({ registry });
+    server = started.server;
+    baseUrl = started.baseUrl;
+  });
+
+  afterEach(async () => {
+    await closeServer(server);
+    server = undefined;
+    // Restore the default (push-into-array) implementation so the rest of
+    // the file's tests continue to work.
+    logAuditEntryMock.mockReset();
+    logAuditEntryMock.mockImplementation((entry: unknown) => {
+      auditEntries.push(entry);
+    });
+  });
+
+  it("POST /sessions succeeds (201) and warn-logs when logAuditEntry throws", async () => {
+    const res = await fetch(`${baseUrl}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({ sessionId: "audit-fail", agentType: "reviewer", allowedTools: ["Read"] }),
+    });
+    expect(res.status).toBe(201);
+    // Registry mutation still happened — the response is honest.
+    expect(registry.size()).toBe(1);
+    // Warn-log captured the audit failure.
+    const warns = mockLogger.warn.mock.calls.map((c) => JSON.stringify(c));
+    expect(warns.some((w) => /audit write failed/i.test(w))).toBe(true);
+  });
+
+  it("DELETE /sessions/:id succeeds (204) and warn-logs when logAuditEntry throws", async () => {
+    registry.register({ sessionId: "audit-fail-2", agentType: "reviewer", allowlist: { patterns: ["Read"] } });
+    mockLogger.warn.mockClear();
+    const res = await fetch(`${baseUrl}/sessions/audit-fail-2`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(204);
+    expect(registry.size()).toBe(0);
+    const warns = mockLogger.warn.mock.calls.map((c) => JSON.stringify(c));
+    expect(warns.some((w) => /audit write failed/i.test(w))).toBe(true);
   });
 });
 

--- a/tests/orchestrator/control-plane.test.ts
+++ b/tests/orchestrator/control-plane.test.ts
@@ -138,6 +138,30 @@ describe("Control-plane HTTP server", () => {
     expect(registry.size()).toBe(0);
   });
 
+  it("POST /sessions rejects allowedTools entries containing control chars / null bytes / unicode (F11)", async () => {
+    const evilPatterns: string[] = [
+      "Read\x00bypass",          // null byte
+      "Read\nWrite",              // newline
+      "Read\rWrite",              // carriage return
+      "Read\tWrite",              // tab
+      "Read​Write",          // zero-width space
+      "Read﻿Write",          // BOM / zero-width no-break space
+      "Read Write",               // plain space
+      "Read;Write",               // shell metachar
+      "Read|Write",               // pipe
+      "<script>",                 // angle brackets
+    ];
+    for (const pattern of evilPatterns) {
+      const res = await fetch(`${baseUrl}/sessions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
+        body: JSON.stringify({ sessionId: "ok", agentType: "reviewer", allowedTools: [pattern] }),
+      });
+      expect(res.status, `pattern ${JSON.stringify(pattern)} should be rejected`).toBe(400);
+    }
+    expect(registry.size()).toBe(0);
+  });
+
   it("POST /sessions accepts prefix wildcards (e.g. echo__*) — only bare catch-alls are rejected", async () => {
     const res = await fetch(`${baseUrl}/sessions`, {
       method: "POST",
@@ -246,6 +270,21 @@ describe("Control-plane HTTP server", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { status: string };
     expect(body.status).toBe("ok");
+  });
+
+  it("undefined paths return JSON 404 (not Express's default HTML), F13", async () => {
+    const res = await fetch(`${baseUrl}/admin`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(404);
+    const ct = res.headers.get("content-type") ?? "";
+    expect(ct).toMatch(/application\/json/i);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Not found");
+    // The default Express HTML 404 reflects the requested path in the body.
+    // Our JSON 404 must not echo the path back.
+    const text = JSON.stringify(body);
+    expect(text).not.toContain("/admin");
   });
 
   it("successful POST /sessions writes an audit entry with direction='control-plane' + structured fields (NOT tool names)", async () => {

--- a/tests/orchestrator/control-plane.test.ts
+++ b/tests/orchestrator/control-plane.test.ts
@@ -138,6 +138,16 @@ describe("Control-plane HTTP server", () => {
     expect(registry.size()).toBe(0);
   });
 
+  it("POST /sessions accepts prefix wildcards (e.g. echo__*) — only bare catch-alls are rejected", async () => {
+    const res = await fetch(`${baseUrl}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({ sessionId: "wild", agentType: "reviewer", allowedTools: ["echo__*", "Read"] }),
+    });
+    expect(res.status).toBe(201);
+    expect(registry.size()).toBe(1);
+  });
+
   it("POST /sessions with valid token + valid body → 201, registry has entry", async () => {
     const res = await fetch(`${baseUrl}/sessions`, {
       method: "POST",
@@ -163,6 +173,9 @@ describe("Control-plane HTTP server", () => {
       { sessionId: "a".repeat(200), agentType: "reviewer", allowedTools: ["Read"] }, // length violation
       { sessionId: "ok", agentType: "x".repeat(50), allowedTools: ["Read"] }, // agentType too long
       { sessionId: "ok", agentType: "reviewer", allowedTools: [] }, // empty allowedTools
+      { sessionId: "ok", agentType: "reviewer", allowedTools: ["*"] }, // bare catch-all rejected (F12)
+      { sessionId: "ok", agentType: "reviewer", allowedTools: ["**"] }, // multi-asterisk catch-all rejected
+      { sessionId: "ok", agentType: "reviewer", allowedTools: ["Read", "*"] }, // mixed list — bare * still rejected
     ];
     for (const body of cases) {
       const res = await fetch(`${baseUrl}/sessions`, {

--- a/tests/orchestrator/session-registry.test.ts
+++ b/tests/orchestrator/session-registry.test.ts
@@ -16,7 +16,7 @@ vi.mock("../../src/logger.js", () => ({
   childLogger: vi.fn(() => mockLogger),
 }));
 
-import { createSessionRegistry } from "../../src/orchestrator/session-registry.js";
+import { createSessionRegistry, MAX_SESSIONS } from "../../src/orchestrator/session-registry.js";
 import type { AllowlistConfig } from "../../src/mcp-proxy/allowlist.js";
 
 const SAMPLE: AllowlistConfig = { patterns: ["echo__read_file"] };
@@ -116,5 +116,43 @@ describe("SessionRegistry", () => {
     expect(registry.size()).toBe(2);
     registry.deregister("x");
     expect(registry.size()).toBe(1);
+  });
+
+  it("register throws when registry is full (defense-in-depth against unbounded growth)", () => {
+    const registry = createSessionRegistry();
+    for (let i = 0; i < MAX_SESSIONS; i++) {
+      registry.register({ sessionId: `s${i}`, agentType: "r", allowlist: SAMPLE });
+    }
+    expect(registry.size()).toBe(MAX_SESSIONS);
+    expect(() =>
+      registry.register({ sessionId: "overflow", agentType: "r", allowlist: SAMPLE })
+    ).toThrow(/full|max/i);
+    expect(registry.size()).toBe(MAX_SESSIONS);
+    // Re-registering an existing sessionId must NOT trip the cap (it's a
+    // slot-overwriting operation, not a fresh allocation).
+    expect(() =>
+      registry.register({ sessionId: "s0", agentType: "c", allowlist: SAMPLE })
+    ).not.toThrow();
+    expect(registry.size()).toBe(MAX_SESSIONS);
+  });
+
+  it("lookup() returns a defensive copy — mutating the returned entry's patterns does not affect internal state", () => {
+    const registry = createSessionRegistry();
+    registry.register({ sessionId: "iso", agentType: "r", allowlist: { patterns: ["Read"] } });
+    const first = registry.lookup("iso");
+    expect(first).toBeDefined();
+    // Cast away readonly to simulate a future caller that ignores the
+    // compile-time annotation. The defensive copy must protect us.
+    (first!.allowlist.patterns as string[]).push("Write");
+    const second = registry.lookup("iso");
+    expect(second?.allowlist.patterns).toEqual(["Read"]);
+  });
+
+  it("list() returns defensive copies — mutating an entry returned by list() does not affect internal state", () => {
+    const registry = createSessionRegistry();
+    registry.register({ sessionId: "iso2", agentType: "r", allowlist: { patterns: ["Read"] } });
+    const listed = registry.list();
+    (listed[0]!.allowlist.patterns as string[]).push("Write");
+    expect(registry.lookup("iso2")?.allowlist.patterns).toEqual(["Read"]);
   });
 });

--- a/tests/orchestrator/session-registry.test.ts
+++ b/tests/orchestrator/session-registry.test.ts
@@ -51,9 +51,12 @@ describe("SessionRegistry", () => {
     expect(registry.lookup("s2")).toBeUndefined();
   });
 
-  it("deregister of unknown sessionId is a no-op (does not throw)", () => {
+  it("deregister returns true when something was removed, false when nothing was there", () => {
     const registry = createSessionRegistry();
-    expect(() => registry.deregister("never-was")).not.toThrow();
+    registry.register({ sessionId: "present", agentType: "r", allowlist: SAMPLE });
+    expect(registry.deregister("present")).toBe(true);
+    expect(registry.deregister("present")).toBe(false);
+    expect(registry.deregister("never-was")).toBe(false);
     expect(registry.size()).toBe(0);
   });
 

--- a/tests/orchestrator/session-registry.test.ts
+++ b/tests/orchestrator/session-registry.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockLogger } = vi.hoisted(() => {
+  const mockLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+  };
+  mockLogger.child.mockReturnValue(mockLogger);
+  return { mockLogger };
+});
+vi.mock("../../src/logger.js", () => ({
+  default: mockLogger,
+  childLogger: vi.fn(() => mockLogger),
+}));
+
+import { createSessionRegistry } from "../../src/orchestrator/session-registry.js";
+import type { AllowlistConfig } from "../../src/mcp-proxy/allowlist.js";
+
+const SAMPLE: AllowlistConfig = { patterns: ["echo__read_file"] };
+
+describe("SessionRegistry", () => {
+  beforeEach(() => {
+    mockLogger.warn.mockClear();
+    mockLogger.info.mockClear();
+  });
+
+  it("register makes lookup return the registered entry", () => {
+    const registry = createSessionRegistry();
+    registry.register({ sessionId: "s1", agentType: "reviewer", allowlist: SAMPLE });
+    const entry = registry.lookup("s1");
+    expect(entry).toBeDefined();
+    expect(entry?.agentType).toBe("reviewer");
+    expect(entry?.allowlist.patterns).toEqual(["echo__read_file"]);
+    expect(typeof entry?.registeredAt).toBe("string");
+    expect(() => new Date(entry!.registeredAt).toISOString()).not.toThrow();
+  });
+
+  it("lookup of unknown sessionId returns undefined", () => {
+    const registry = createSessionRegistry();
+    expect(registry.lookup("nope")).toBeUndefined();
+  });
+
+  it("deregister removes the session; subsequent lookup returns undefined", () => {
+    const registry = createSessionRegistry();
+    registry.register({ sessionId: "s2", agentType: "coder", allowlist: SAMPLE });
+    expect(registry.lookup("s2")).toBeDefined();
+    registry.deregister("s2");
+    expect(registry.lookup("s2")).toBeUndefined();
+  });
+
+  it("deregister of unknown sessionId is a no-op (does not throw)", () => {
+    const registry = createSessionRegistry();
+    expect(() => registry.deregister("never-was")).not.toThrow();
+    expect(registry.size()).toBe(0);
+  });
+
+  it("list() returns shallow copies — mutating the returned array does not affect internal state", () => {
+    const registry = createSessionRegistry();
+    registry.register({ sessionId: "a", agentType: "reviewer", allowlist: SAMPLE });
+    registry.register({ sessionId: "b", agentType: "coder", allowlist: SAMPLE });
+    const listed = registry.list();
+    expect(listed).toHaveLength(2);
+    expect(listed.map((e) => e.sessionId).sort()).toEqual(["a", "b"]);
+    listed.length = 0;
+    expect(registry.size()).toBe(2);
+    expect(registry.lookup("a")).toBeDefined();
+    expect(registry.lookup("b")).toBeDefined();
+  });
+
+  it("re-register of same sessionId overwrites and warn-logs once", () => {
+    const registry = createSessionRegistry();
+    registry.register({ sessionId: "dup", agentType: "reviewer", allowlist: { patterns: ["A"] } });
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    registry.register({ sessionId: "dup", agentType: "coder", allowlist: { patterns: ["B"] } });
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "dup" }),
+      expect.stringMatching(/re-register/i)
+    );
+    const entry = registry.lookup("dup");
+    expect(entry?.agentType).toBe("coder");
+    expect(entry?.allowlist.patterns).toEqual(["B"]);
+  });
+
+  it("register rejects malformed input (defensive second line of defence)", () => {
+    const registry = createSessionRegistry();
+    expect(() =>
+      registry.register({ sessionId: "", agentType: "x", allowlist: SAMPLE })
+    ).toThrow(/sessionId/i);
+    expect(() =>
+      // @ts-expect-error — runtime check for non-string
+      registry.register({ sessionId: 123, agentType: "x", allowlist: SAMPLE })
+    ).toThrow(/sessionId/i);
+    expect(() =>
+      registry.register({ sessionId: "ok", agentType: "x", allowlist: { patterns: [] } })
+    ).toThrow(/allowlist|patterns|empty/i);
+    expect(() =>
+      // @ts-expect-error — runtime check for non-array
+      registry.register({ sessionId: "ok", agentType: "x", allowlist: { patterns: "Read" } })
+    ).toThrow(/allowlist|patterns|array/i);
+    expect(() =>
+      registry.register({ sessionId: "ok", agentType: "", allowlist: SAMPLE })
+    ).toThrow(/agentType/i);
+    expect(registry.size()).toBe(0);
+  });
+
+  it("size() returns the number of registered sessions", () => {
+    const registry = createSessionRegistry();
+    expect(registry.size()).toBe(0);
+    registry.register({ sessionId: "x", agentType: "r", allowlist: SAMPLE });
+    expect(registry.size()).toBe(1);
+    registry.register({ sessionId: "y", agentType: "c", allowlist: SAMPLE });
+    expect(registry.size()).toBe(2);
+    registry.deregister("x");
+    expect(registry.size()).toBe(1);
+  });
+});

--- a/tests/server-per-session-allowlist.test.ts
+++ b/tests/server-per-session-allowlist.test.ts
@@ -202,15 +202,22 @@ describe("Tier 1.3 — proxy uses per-session allowlist when registered", () => 
     expect(recorder.recordBlockedRequest).toHaveBeenCalledWith("allowlist");
   });
 
-  it("malformed sessionId header (Tier 1.1 strips it) → falls through to global, NOT to a coincidentally-registered entry", async () => {
-    // Strongest version of this guard: register an entry under the EXACT
-    // string the malformed header carries. A buggy proxy that keyed registry
-    // lookups off the raw req.header() value (instead of the Tier 1.1-parsed
-    // sessionId) would match this entry and allow Write. The correct
-    // behaviour: identity-header parser rejects the header (charset violation),
-    // sessionId becomes undefined, registry is NOT consulted, request falls
-    // through to global allowlist — Write is blocked.
-    registry.register({ sessionId: "bad value!", agentType: "reviewer", allowlist: { patterns: ["Write"] } });
+  it("registry refuses to hold a sessionId that the identity-header parser would reject — guard is by construction", () => {
+    // F5 follow-on: now that the registry's validate() shares the contract
+    // with the HTTP layer, a malformed sessionId can never enter the registry
+    // in the first place. The guard against "malformed header accidentally
+    // matches a registered entry" becomes a by-construction property, not a
+    // runtime one. This test locks in the by-construction part.
+    expect(() =>
+      registry.register({ sessionId: "bad value!", agentType: "reviewer", allowlist: { patterns: ["Write"] } })
+    ).toThrow(/sessionId/i);
+  });
+
+  it("malformed sessionId header → Tier 1.1 strips it → falls through to global allowlist (parser is the guard)", async () => {
+    // Even with no entry under "bad value!" (registry refused to register
+    // one), confirm the proxy correctly handles malformed headers by
+    // dropping the parsed sessionId to undefined and falling through to
+    // the global allowlist. Global allows Read, blocks Write.
     const writeRes = await mcpCall(url, 1, "Write", {}, { "X-Agent-Session-Id": "bad value!" });
     const writeJson = (await writeRes.json()) as { error?: { code: number } };
     expect(writeJson.error?.code).toBe(-32600);

--- a/tests/server-per-session-allowlist.test.ts
+++ b/tests/server-per-session-allowlist.test.ts
@@ -219,3 +219,44 @@ describe("Tier 1.3 — proxy uses per-session allowlist when registered", () => 
     expect(readJson.result).toBeDefined();
   });
 });
+
+describe("Tier 1.3 — registry.lookup() throwing falls through to global (anchor #C5)", () => {
+  let server: Server;
+  let url: string;
+
+  beforeEach(async () => {
+    auditEntries.length = 0;
+    // Inject a registry whose lookup() throws. The proxy MUST NOT propagate
+    // this — observability/orchestration failures never break the request
+    // path (anchor #C5). Falls through to global allowlist with a warn-log.
+    const throwingRegistry = {
+      lookup: () => {
+        throw new Error("boom (simulated registry failure)");
+      },
+    };
+    const started = await startServer(makeConfig({
+      bridge: makeBridge(),
+      serverRoutes: { Read: "fs", Write: "fs", Grep: "fs" },
+      registry: throwingRegistry,
+    }));
+    server = started.server;
+    url = started.url;
+  });
+
+  afterEach(async () => {
+    await closeServer(server);
+  });
+
+  it("request with sessionId set + registry.lookup() throws → uses global allowlist, request still processes", async () => {
+    // Global allowlist is ["Read", "Grep"]. Read should be allowed even
+    // though every registry lookup throws.
+    const readRes = await mcpCall(url, 1, "Read", {}, { "X-Agent-Session-Id": "anything" });
+    const readJson = (await readRes.json()) as { result?: unknown; error?: unknown };
+    expect(readJson.result).toBeDefined();
+    expect(readJson.error).toBeUndefined();
+
+    const writeRes = await mcpCall(url, 2, "Write", {}, { "X-Agent-Session-Id": "anything" });
+    const writeJson = (await writeRes.json()) as { error?: { code: number } };
+    expect(writeJson.error?.code).toBe(-32600);
+  });
+});

--- a/tests/server-per-session-allowlist.test.ts
+++ b/tests/server-per-session-allowlist.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+
+/**
+ * Tier 1.3 — proxy-side integration of the SessionRegistry.
+ *
+ * The proxy consults the registry at the existing allowlist-check call site
+ * (src/mcp-proxy/server.ts). When the request has a sessionId AND the
+ * registry has an entry for it, the per-session allowlist is used; otherwise
+ * the request falls through to the global allowlist (Phase 1 behaviour).
+ *
+ * Locked-in invariants:
+ *   - Lookup precedence: per-session > global. A registered session NEVER
+ *     uses the global allowlist.
+ *   - Lookup miss is silent: a sessionId that the registry doesn't know about
+ *     falls through to global, never blocks the request.
+ *   - Audit entries on per-session blocks carry the sessionId so operators
+ *     can demux per-agent post-incident.
+ *   - Malformed sessionId headers (which Tier 1.1 turns into undefined) NEVER
+ *     accidentally use a registered allowlist.
+ */
+
+const { mockLogger, auditEntries } = vi.hoisted(() => {
+  const mockLogger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn(),
+  };
+  mockLogger.child.mockReturnValue(mockLogger);
+  const auditEntries: unknown[] = [];
+  return { mockLogger, auditEntries };
+});
+vi.mock("../src/logger.js", () => ({
+  default: mockLogger, childLogger: vi.fn(() => mockLogger),
+}));
+vi.mock("../src/mcp-proxy/logger.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/mcp-proxy/logger.js")>(
+    "../src/mcp-proxy/logger.js"
+  );
+  return {
+    ...actual,
+    logAuditEntry: vi.fn((entry: unknown) => {
+      auditEntries.push(entry);
+    }),
+  };
+});
+
+import { createProxyServer, type ProxyServerConfig } from "../src/mcp-proxy/server.js";
+import { createSessionRegistry, type SessionRegistry } from "../src/orchestrator/session-registry.js";
+import type { StdioBridge } from "../src/mcp-proxy/stdio-bridge.js";
+import type { AuditEntry } from "../src/mcp-proxy/logger.js";
+import type { MetricsRecorder } from "../src/observability/metrics.js";
+
+interface SpyRecorder extends MetricsRecorder {
+  recordRequest: ReturnType<typeof vi.fn>;
+  recordBlockedRequest: ReturnType<typeof vi.fn>;
+}
+
+function makeBridge(): StdioBridge {
+  return {
+    call: vi.fn(async () => ({ content: "ok" })),
+    shutdown: vi.fn(async () => {}),
+  } as unknown as StdioBridge;
+}
+
+function makeSpyRecorder(): SpyRecorder {
+  return {
+    recordRequest: vi.fn(),
+    recordInjectionFlag: vi.fn(),
+    recordBlockedRequest: vi.fn(),
+    metricsText: vi.fn(async () => ({ contentType: "text/plain", body: "" })),
+    shutdown: vi.fn(async () => {}),
+  };
+}
+
+function makeConfig(overrides: Partial<ProxyServerConfig> = {}): ProxyServerConfig {
+  return {
+    port: 0,
+    // Global allowlist matches what Phase 1 deployments use — exact tool names.
+    allowedTools: ["Read", "Grep"],
+    logLevel: "error",
+    ...overrides,
+  };
+}
+
+async function startServer(config: ProxyServerConfig): Promise<{ server: Server; url: string }> {
+  const app = createProxyServer(config);
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const addr = server.address() as AddressInfo;
+  return { server, url: `http://127.0.0.1:${addr.port}/mcp` };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function mcpCall(
+  url: string,
+  id: number,
+  toolName: string,
+  args: Record<string, unknown> = {},
+  headers: Record<string, string> = {}
+) {
+  return fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: { name: toolName, arguments: args },
+    }),
+  });
+}
+
+describe("Tier 1.3 — proxy uses per-session allowlist when registered", () => {
+  let server: Server;
+  let url: string;
+  let registry: SessionRegistry;
+  let recorder: SpyRecorder;
+
+  beforeEach(async () => {
+    auditEntries.length = 0;
+    registry = createSessionRegistry();
+    recorder = makeSpyRecorder();
+    const started = await startServer(makeConfig({
+      bridge: makeBridge(),
+      serverRoutes: { Read: "fs", Write: "fs", Grep: "fs" },
+      registry,
+      recorder,
+    }));
+    server = started.server;
+    url = started.url;
+  });
+
+  afterEach(async () => {
+    await closeServer(server);
+  });
+
+  it("session A registered with [Read] → Read is allowed, Write is blocked (uses A's allowlist)", async () => {
+    registry.register({ sessionId: "A", agentType: "reviewer", allowlist: { patterns: ["Read"] } });
+    const allowed = await mcpCall(url, 1, "Read", {}, { "X-Agent-Session-Id": "A" });
+    expect(allowed.status).toBe(200);
+    const allowedJson = (await allowed.json()) as { result?: unknown; error?: unknown };
+    expect(allowedJson.result).toBeDefined();
+    expect(allowedJson.error).toBeUndefined();
+
+    const blocked = await mcpCall(url, 2, "Write", {}, { "X-Agent-Session-Id": "A" });
+    const blockedJson = (await blocked.json()) as { error?: { code: number; message: string } };
+    expect(blockedJson.error?.code).toBe(-32600);
+    expect(blockedJson.error?.message).toMatch(/allowlist/i);
+  });
+
+  it("session B registered with [Write] → Write is allowed, Read is blocked (independent of A)", async () => {
+    registry.register({ sessionId: "A", agentType: "reviewer", allowlist: { patterns: ["Read"] } });
+    registry.register({ sessionId: "B", agentType: "coder", allowlist: { patterns: ["Write"] } });
+    const allowed = await mcpCall(url, 1, "Write", {}, { "X-Agent-Session-Id": "B" });
+    const allowedJson = (await allowed.json()) as { result?: unknown; error?: unknown };
+    expect(allowedJson.result).toBeDefined();
+
+    const blocked = await mcpCall(url, 2, "Read", {}, { "X-Agent-Session-Id": "B" });
+    const blockedJson = (await blocked.json()) as { error?: { code: number; message: string } };
+    expect(blockedJson.error?.code).toBe(-32600);
+  });
+
+  it("sessionId is set but registry has no entry → falls through to global ALLOWED_TOOLS", async () => {
+    // Global allowlist is ["Read", "Grep"]. Session "C" not registered.
+    const readRes = await mcpCall(url, 1, "Read", {}, { "X-Agent-Session-Id": "C" });
+    const readJson = (await readRes.json()) as { result?: unknown; error?: unknown };
+    expect(readJson.result).toBeDefined();
+
+    const writeRes = await mcpCall(url, 2, "Write", {}, { "X-Agent-Session-Id": "C" });
+    const writeJson = (await writeRes.json()) as { error?: { code: number } };
+    expect(writeJson.error?.code).toBe(-32600);
+  });
+
+  it("no X-Agent-Session-Id header → uses global allowlist (Phase 1 backward compat)", async () => {
+    const readRes = await mcpCall(url, 1, "Read", {});
+    const readJson = (await readRes.json()) as { result?: unknown };
+    expect(readJson.result).toBeDefined();
+
+    const writeRes = await mcpCall(url, 2, "Write", {});
+    const writeJson = (await writeRes.json()) as { error?: { code: number } };
+    expect(writeJson.error?.code).toBe(-32600);
+  });
+
+  it("audit entry on per-session block carries sessionId AND reason='allowlist'", async () => {
+    registry.register({ sessionId: "audit-sess", agentType: "reviewer", allowlist: { patterns: ["Read"] } });
+    await mcpCall(url, 1, "Write", {}, { "X-Agent-Session-Id": "audit-sess", "X-Agent-Type": "reviewer" });
+    const blockedEntry = (auditEntries as AuditEntry[]).find((e) => e.status === "blocked");
+    expect(blockedEntry).toBeDefined();
+    expect(blockedEntry!.sessionId).toBe("audit-sess");
+    expect(blockedEntry!.agentType).toBe("reviewer");
+    // Reason is "allowlist" regardless of which list blocked it. Operators
+    // distinguish per-session vs global blocks via the sessionId field.
+    expect(recorder.recordBlockedRequest).toHaveBeenCalledWith("allowlist");
+  });
+
+  it("global block (no sessionId) records the same block reason as a per-session block", async () => {
+    await mcpCall(url, 1, "Write", {});
+    expect(recorder.recordBlockedRequest).toHaveBeenCalledWith("allowlist");
+  });
+
+  it("malformed sessionId header (Tier 1.1 strips it) → falls through to global, NOT to a coincidentally-registered entry", async () => {
+    // Strongest version of this guard: register an entry under the EXACT
+    // string the malformed header carries. A buggy proxy that keyed registry
+    // lookups off the raw req.header() value (instead of the Tier 1.1-parsed
+    // sessionId) would match this entry and allow Write. The correct
+    // behaviour: identity-header parser rejects the header (charset violation),
+    // sessionId becomes undefined, registry is NOT consulted, request falls
+    // through to global allowlist — Write is blocked.
+    registry.register({ sessionId: "bad value!", agentType: "reviewer", allowlist: { patterns: ["Write"] } });
+    const writeRes = await mcpCall(url, 1, "Write", {}, { "X-Agent-Session-Id": "bad value!" });
+    const writeJson = (await writeRes.json()) as { error?: { code: number } };
+    expect(writeJson.error?.code).toBe(-32600);
+    const readRes = await mcpCall(url, 2, "Read", {}, { "X-Agent-Session-Id": "bad value!" });
+    const readJson = (await readRes.json()) as { result?: unknown };
+    expect(readJson.result).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #56. Tier 1.3 of the Phase 2 multi-agent groundwork.

- Introduces in-memory `SessionRegistry` and a loopback control-plane HTTP server (`127.0.0.1:18924`, bearer-token gated) that lets an external dispatch CLI / MC connector register per-session allowlists.
- Per-session allowlists override the global `ALLOWED_TOOLS` list when the request carries an `X-Agent-Session-Id` matching a registered session.
- Phase 1 single-agent deployments are unchanged: with `MCP_CONTROL_TOKEN` unset the control plane does not start and the proxy continues with the global list exactly as before.

## Security shape (NEW HTTP attack surface)

- **Loopback bind on `127.0.0.1:18924`** — hard-coded in `src/index.ts`. No `MCP_CONTROL_BIND` env knob (would be an operator footgun that could silently void the primary defence).
- **Bearer-token gate** — `crypto.timingSafeEqual` with explicit length check (wrong-length tokens return 401, not 400 — no length-probe distinguisher).
- **Token never logs** — not into audit NDJSON, Langfuse traces, Prometheus output, MC adapter payloads, or stdout. Locked in by `tests/orchestrator/control-plane.test.ts`.
- **Audit hygiene** — successful register/deregister write a `direction: "control-plane"` audit entry capturing `action`, `sessionId`, `agentType`, `remoteAddress`, `remotePort`, and `allowedToolsCount` — but **never** the tool names themselves. 401/400 rejections warn-log only (probe flood guard).
- **Type-level immutability** — the proxy receives `Pick<SessionRegistry, "lookup">`, so the request path can never mutate the registry even via TypeScript escape hatches.

The full threat decomposition (six concerns, six defences) lives in `docs/security.md` under `Control-plane trust boundary`.

## TDD breakdown

- `tests/orchestrator/session-registry.test.ts` — 8 unit tests (register/lookup/deregister/list, validation, re-register warn).
- `tests/orchestrator/control-plane.test.ts` — 18 HTTP tests covering auth (missing/malformed/wrong-token/wrong-length), payload validation, audit invariants, the source-grep that asserts `127.0.0.1` literal and absence of any `MCP_CONTROL_BIND` env read, and the token-never-logs assertion.
- `tests/server-per-session-allowlist.test.ts` — 7 proxy-integration tests covering lookup precedence, fall-through on miss, malformed-sessionId guard, and Prometheus block-reason labels.

Test count: **616 → 649** (all green). Typecheck + build clean.

## Manual end-to-end (smoke verified inside the sandbox)

```
# token unset → control plane NOT listening, warn-log emitted
node dist/index.js  →  /health 200, 18924 connection refused

# token set → register → per-session block → deregister
TOKEN=$(openssl rand -hex 32)
curl -X POST http://127.0.0.1:18924/sessions \
  -H "Authorization: Bearer $TOKEN" \
  -d '{"sessionId":"manual-1","agentType":"reviewer","allowedTools":["echo__read_file"]}'
# → 201

curl -X POST http://127.0.0.1:18923/mcp \
  -H "X-Agent-Session-Id: manual-1" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"Read","arguments":{}}}'
# → -32600 "Tool \"Read\" is not in the allowlist"

curl -X DELETE http://127.0.0.1:18924/sessions/manual-1 -H "Authorization: Bearer $TOKEN"
# → 204
```

Token value never appears in any captured log line or audit entry — verified by `grep -F` on the captured stdout/stderr.

## Test plan

- [x] `npm test` inside sbx sandbox — 649/649 green
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] Manual smoke (above) — control plane disabled when token unset, enabled when set, register/deregister round-trip, per-session block, no token leakage
- [x] `pr-review-toolkit:review-pr` — recommended next
- [ ] `/ultrareview` — **recommended** for this PR (security-critical: introduces a new HTTP attack surface)
- [ ] `./scripts/sandbox-run.sh` — backward-compat (Phase 1 single-agent flow with no token, no header) covered by smoke 1; full script needs darwin-arm64 host node_modules so it's skipped from the worktree, suitable to re-run from the merge-checkout if reviewers want belt-and-braces verification

## Files

**Add:**
- `src/orchestrator/session-registry.ts`
- `src/orchestrator/control-plane.ts`
- `tests/orchestrator/session-registry.test.ts`
- `tests/orchestrator/control-plane.test.ts`
- `tests/server-per-session-allowlist.test.ts`

**Modify:**
- `src/mcp-proxy/server.ts` — registry consult at the existing allowlist-check call site
- `src/mcp-proxy/logger.ts` — extend `AuditEntry["direction"]` to `"control-plane"` and add control-plane fields
- `src/index.ts` — read `MCP_CONTROL_TOKEN` / `MCP_CONTROL_PORT`, optionally start control plane, register graceful shutdown
- `docs/security.md` — Control-plane trust boundary section (threat decomposition, audit invariants)
- `docs/architecture.md` — topology diagram + control-plane port note
- `.env.example` — `MCP_CONTROL_TOKEN`, `MCP_CONTROL_PORT`

## Plan file

`~/.claude/plans/agentic-press-tier-1-3-session-registry.md` (Plan-Mode approved before implementation began).

🤖 Generated with [Claude Code](https://claude.com/claude-code)