### PR TITLE
chore: warn instead of swallowing fs errors in readVendoredSkills (#61)

### DIFF
--- a/src/improvements/skill-usage-report.ts
+++ b/src/improvements/skill-usage-report.ts
@@ -114,6 +114,10 @@ const PROVENANCE_MARKER = "## Provenance";
  * Scan `.claude/skills/` for vendored skills — those whose SKILL.md carries
  * the provenance footer marker. Project-authored skills (without the marker)
  * are excluded so the trial's metrics stay scoped to the cherry-picked set.
+ *
+ * An fs error on a single skill (EACCES, EISDIR, ENOENT on a stale symlink,
+ * etc.) emits a `[readVendoredSkills]` warning and skips that skill —
+ * other readable skills are still returned, and the sweep continues.
  */
 export function readVendoredSkills(skillsDir: string): VendoredSkill[] {
   if (!existsSync(skillsDir)) return [];
@@ -124,9 +128,7 @@ export function readVendoredSkills(skillsDir: string): VendoredSkill[] {
     try {
       isDir = statSync(skillDir).isDirectory();
     } catch (err) {
-      console.warn(
-        `[readVendoredSkills] skipped ${name}: ${(err as Error).message}`
-      );
+      warnSkipped(name, err);
       continue;
     }
     if (!isDir) continue;
@@ -138,15 +140,25 @@ export function readVendoredSkills(skillsDir: string): VendoredSkill[] {
       content = readFileSync(skillMd, "utf8");
       mtime = statSync(skillMd).mtime;
     } catch (err) {
-      console.warn(
-        `[readVendoredSkills] skipped ${name}: ${(err as Error).message}`
-      );
+      warnSkipped(name, err);
       continue;
     }
     if (!content.includes(PROVENANCE_MARKER)) continue;
     out.push({ name, skillMdPath: skillMd, skillMdMtime: mtime });
   }
   return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function warnSkipped(name: string, err: unknown): void {
+  // Mirrors the catch-narrowing convention used in `src/mcp-proxy/logger.ts`
+  // (`err instanceof Error ? err.message : String(err)`). The `.code` prefix
+  // surfaces NodeJS.ErrnoException codes (EACCES vs ENOENT vs EMFILE) so the
+  // launchd sweep log gives operators a triage signal, not just prose.
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  const message = err instanceof Error ? err.message : String(err);
+  console.warn(
+    `[readVendoredSkills] skipped ${name}: ${code ?? "UNKNOWN"} ${message}`
+  );
 }
 
 export function computeMetrics(

--- a/src/improvements/skill-usage-report.ts
+++ b/src/improvements/skill-usage-report.ts
@@ -123,7 +123,10 @@ export function readVendoredSkills(skillsDir: string): VendoredSkill[] {
     let isDir = false;
     try {
       isDir = statSync(skillDir).isDirectory();
-    } catch {
+    } catch (err) {
+      console.warn(
+        `[readVendoredSkills] skipped ${name}: ${(err as Error).message}`
+      );
       continue;
     }
     if (!isDir) continue;
@@ -134,7 +137,10 @@ export function readVendoredSkills(skillsDir: string): VendoredSkill[] {
     try {
       content = readFileSync(skillMd, "utf8");
       mtime = statSync(skillMd).mtime;
-    } catch {
+    } catch (err) {
+      console.warn(
+        `[readVendoredSkills] skipped ${name}: ${(err as Error).message}`
+      );
       continue;
     }
     if (!content.includes(PROVENANCE_MARKER)) continue;

--- a/tests/improvements/skill-usage-report.test.ts
+++ b/tests/improvements/skill-usage-report.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, utimesSync } from "node:fs";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, utimesSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -376,5 +376,40 @@ describe("readVendoredSkills", () => {
     writeFileSync(join(skillsRoot, "loose-file.md"), "## Provenance\n");
     mkdirSync(join(skillsRoot, "no-skill-md-here"));
     expect(readVendoredSkills(skillsRoot)).toEqual([]);
+  });
+
+  it("warns and continues when a SKILL.md is unreadable, returning the readable skills", () => {
+    // Skip under root (e.g., some CI / docker images) where chmod 000 doesn't
+    // produce EACCES on read — the test then can't provoke the catch path.
+    if (typeof process.getuid === "function" && process.getuid() === 0) {
+      return;
+    }
+    const skillsRoot = join(tmpRoot, ".claude", "skills");
+    mkdirSync(join(skillsRoot, "readable"), { recursive: true });
+    mkdirSync(join(skillsRoot, "unreadable"), { recursive: true });
+    const readableMd = join(skillsRoot, "readable", "SKILL.md");
+    const unreadableMd = join(skillsRoot, "unreadable", "SKILL.md");
+    writeFileSync(
+      readableMd,
+      "---\nname: readable\n---\n\n# X\n\n## Provenance\n\nVendored.\n"
+    );
+    writeFileSync(
+      unreadableMd,
+      "---\nname: unreadable\n---\n\n# X\n\n## Provenance\n\nVendored.\n"
+    );
+    chmodSync(unreadableMd, 0o000);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const skills = readVendoredSkills(skillsRoot);
+      expect(skills.map((s) => s.name)).toEqual(["readable"]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]![0]);
+      expect(message).toMatch(/^\[readVendoredSkills\] skipped unreadable: /);
+    } finally {
+      // Restore perms so afterEach rmSync can clean up the tmp dir.
+      chmodSync(unreadableMd, 0o644);
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/tests/improvements/skill-usage-report.test.ts
+++ b/tests/improvements/skill-usage-report.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, utimesSync, chmodSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, utimesSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -378,26 +378,16 @@ describe("readVendoredSkills", () => {
     expect(readVendoredSkills(skillsRoot)).toEqual([]);
   });
 
-  it("warns and continues when a SKILL.md is unreadable, returning the readable skills", () => {
-    // Skip under root (e.g., some CI / docker images) where chmod 000 doesn't
-    // produce EACCES on read — the test then can't provoke the catch path.
-    if (typeof process.getuid === "function" && process.getuid() === 0) {
-      return;
-    }
+  it("warns and continues when the skill directory can't be stat'd (broken symlink), returning readable siblings", () => {
+    // Triggers the `statSync(skillDir)` catch. A broken symlink is portable
+    // (no uid dependency) and provokes ENOENT when stat follows the link.
     const skillsRoot = join(tmpRoot, ".claude", "skills");
     mkdirSync(join(skillsRoot, "readable"), { recursive: true });
-    mkdirSync(join(skillsRoot, "unreadable"), { recursive: true });
-    const readableMd = join(skillsRoot, "readable", "SKILL.md");
-    const unreadableMd = join(skillsRoot, "unreadable", "SKILL.md");
     writeFileSync(
-      readableMd,
-      "---\nname: readable\n---\n\n# X\n\n## Provenance\n\nVendored.\n"
+      join(skillsRoot, "readable", "SKILL.md"),
+      "---\nname: readable\n---\n\n## Provenance\n\nVendored.\n"
     );
-    writeFileSync(
-      unreadableMd,
-      "---\nname: unreadable\n---\n\n# X\n\n## Provenance\n\nVendored.\n"
-    );
-    chmodSync(unreadableMd, 0o000);
+    symlinkSync(join(tmpRoot, "definitely-not-here"), join(skillsRoot, "broken-link"));
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
@@ -405,10 +395,35 @@ describe("readVendoredSkills", () => {
       expect(skills.map((s) => s.name)).toEqual(["readable"]);
       expect(warnSpy).toHaveBeenCalledTimes(1);
       const message = String(warnSpy.mock.calls[0]![0]);
-      expect(message).toMatch(/^\[readVendoredSkills\] skipped unreadable: /);
+      expect(message).toContain("[readVendoredSkills]");
+      expect(message).toContain("broken-link");
     } finally {
-      // Restore perms so afterEach rmSync can clean up the tmp dir.
-      chmodSync(unreadableMd, 0o644);
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("warns and continues when SKILL.md is unreadable, returning readable siblings", () => {
+    // Triggers the `readFileSync(skillMd)` catch. A directory at the SKILL.md
+    // path provokes EISDIR — portable across uid and platform, unlike
+    // chmod 000 which is a no-op under root (some CI / docker images).
+    const skillsRoot = join(tmpRoot, ".claude", "skills");
+    mkdirSync(join(skillsRoot, "readable"), { recursive: true });
+    mkdirSync(join(skillsRoot, "wedged"), { recursive: true });
+    writeFileSync(
+      join(skillsRoot, "readable", "SKILL.md"),
+      "---\nname: readable\n---\n\n## Provenance\n\nVendored.\n"
+    );
+    mkdirSync(join(skillsRoot, "wedged", "SKILL.md"));
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const skills = readVendoredSkills(skillsRoot);
+      expect(skills.map((s) => s.name)).toEqual(["readable"]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]![0]);
+      expect(message).toContain("[readVendoredSkills]");
+      expect(message).toContain("wedged");
+    } finally {
       warnSpy.mockRestore();
     }
   });


### PR DESCRIPTION
## Summary

- Replace both bare `catch { continue; }` blocks in `src/improvements/skill-usage-report.ts:readVendoredSkills` with `catch (err) { console.warn(\`[readVendoredSkills] skipped <name>: <err.message>\`); continue; }`.
- Preserves existing skip-and-continue semantics — a single corrupt skill still does not kill the sweep. Only the silence is fixed.
- Per #61: pre-#55 the silent skip just meant "fewer rows"; post-#55 it understates `trialInvocations` and could mask DROP/KEEP decisions on 2026-05-30. The warning now lands in stderr → launchd's `~/Library/Logs/agentic-press-skill-metrics.log` during the weekly sweep.

## Test plan

- [x] New test (`tests/improvements/skill-usage-report.test.ts`): temp dir with one readable + one `chmod 000` SKILL.md asserts the warning emits with the expected prefix AND the readable skill still comes back. Test skips under root (Docker/CI) where `chmod 000` doesn't yield EACCES on read.
- [x] Full vitest suite passes (744 tests).
- [x] `npm run typecheck` clean.
- [x] No new dependencies.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)