### PR TITLE
fix: sweep-improvements exits non-zero when a phase fails (#64)

### DIFF
--- a/scripts/sweep-improvements.mjs
+++ b/scripts/sweep-improvements.mjs
@@ -84,19 +84,25 @@ let auditWritten = 0;
 let auditSkipped = 0;
 let skillMetricsWritten = 0;
 let skillMetricsSkipped = 0;
+// Phase-failure escalation: each phase catches its own exceptions so one
+// bad phase does not block the other, but any phase failure escalates to
+// a non-zero process exit code at the bottom of the script so launchd /
+// CI gates can detect it. Each catch must (1) set its *Failed flag and
+// (2) call logPhaseFailure to emit a structured stderr line.
 let auditFailed = false;
 let skillMetricsFailed = false;
 
-// Phase-level catches preserve the "one bad phase does not block the other"
-// invariant. The phase-failed flags drive the final non-zero exit so the
-// sweep failure is visible (launchd surfaces a non-zero exit; a buried
-// console.error in a log file nobody reads is not enough — see #64).
+/**
+ * Emit `[sweep:<phase>] FAILED (<name> <code>): <message>` plus stack
+ * (when present) to stderr. Mirrors the catch-narrowing convention in
+ * `src/improvements/skill-usage-report.ts:warnSkipped`.
+ */
 function logPhaseFailure(phase, err) {
-  const code = err && err.code ? err.code : "UNKNOWN";
-  const name = err && err.name ? err.name : "Error";
+  const code = err?.code ?? "UNKNOWN";
+  const name = err?.name ?? "Error";
   const message = err instanceof Error ? err.message : String(err);
   console.error(`[sweep:${phase}] FAILED (${name} ${code}): ${message}`);
-  if (err && err.stack) console.error(err.stack);
+  if (err?.stack) console.error(err.stack);
 }
 
 // ---- Phase 1: Audit ----
@@ -197,9 +203,8 @@ console.log(
 );
 
 if (auditFailed || skillMetricsFailed) {
-  // Non-zero exit so launchd's wrapper sees the failure (and so any future
-  // CI invocation gates on it). Both phases still ran — see logPhaseFailure
-  // above — only the final exit code is escalated.
+  // process.exitCode (not process.exit) so the event loop drains stdio
+  // cleanly. Both phases have already run; this only escalates the code.
   process.exitCode = 1;
 }
 

--- a/scripts/sweep-improvements.mjs
+++ b/scripts/sweep-improvements.mjs
@@ -84,6 +84,20 @@ let auditWritten = 0;
 let auditSkipped = 0;
 let skillMetricsWritten = 0;
 let skillMetricsSkipped = 0;
+let auditFailed = false;
+let skillMetricsFailed = false;
+
+// Phase-level catches preserve the "one bad phase does not block the other"
+// invariant. The phase-failed flags drive the final non-zero exit so the
+// sweep failure is visible (launchd surfaces a non-zero exit; a buried
+// console.error in a log file nobody reads is not enough — see #64).
+function logPhaseFailure(phase, err) {
+  const code = err && err.code ? err.code : "UNKNOWN";
+  const name = err && err.name ? err.name : "Error";
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`[sweep:${phase}] FAILED (${name} ${code}): ${message}`);
+  if (err && err.stack) console.error(err.stack);
+}
 
 // ---- Phase 1: Audit ----
 if (!opts.skipAudit) {
@@ -112,8 +126,8 @@ if (!opts.skipAudit) {
         auditWritten++;
       }
     } catch (err) {
-      console.error(`[sweep:audit] FAILED: ${err.message}`);
-      if (err.stack) console.error(err.stack);
+      auditFailed = true;
+      logPhaseFailure("audit", err);
     }
   }
 }
@@ -173,14 +187,21 @@ if (!opts.skipSkillMetrics) {
       }
     }
   } catch (err) {
-    console.error(`[sweep:skill] FAILED: ${err.message}`);
-    if (err.stack) console.error(err.stack);
+    skillMetricsFailed = true;
+    logPhaseFailure("skill", err);
   }
 }
 
 console.log(
   `[sweep] done — audit: wrote ${auditWritten}, skipped ${auditSkipped} | skill: wrote ${skillMetricsWritten}, skipped ${skillMetricsSkipped}`
 );
+
+if (auditFailed || skillMetricsFailed) {
+  // Non-zero exit so launchd's wrapper sees the failure (and so any future
+  // CI invocation gates on it). Both phases still ran — see logPhaseFailure
+  // above — only the final exit code is escalated.
+  process.exitCode = 1;
+}
 
 function parseEntries(text) {
   const entries = [];

--- a/tests/scripts/sweep-improvements-error-handling.test.ts
+++ b/tests/scripts/sweep-improvements-error-handling.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Integration tests for the .mjs sweep script. Invoked via the same tsx
+// wrapper used by `npm run sweep-improvements` so transpilation matches prod.
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const SCRIPT = "scripts/sweep-improvements.mjs";
+
+function runSweep(args: string[]): ReturnType<typeof spawnSync> {
+  return spawnSync("npx", ["tsx", SCRIPT, ...args], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+}
+
+let tmpRoot: string;
+let outDir: string;
+let emptySkillsDir: string;
+let emptySessionDir: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "sweep-err-"));
+  outDir = join(tmpRoot, "improvements");
+  // Both are nonexistent on purpose — phase 2 then exits early via the
+  // "no vendored skills found" branch, which keeps the test deterministic
+  // (no dependency on host ~/.claude/projects state).
+  emptySkillsDir = join(tmpRoot, "skills");
+  emptySessionDir = join(tmpRoot, "sessions");
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("sweep-improvements error handling (#64)", () => {
+  it("exits non-zero when the audit phase throws on a missing --input file", () => {
+    const missingInput = join(tmpRoot, "does-not-exist.ndjson");
+    const result = runSweep([
+      "--input", missingInput,
+      "--dir", outDir,
+      "--skills-dir", emptySkillsDir,
+      "--session-log-dir", emptySessionDir,
+    ]);
+
+    expect(result.status).not.toBe(0);
+  });
+
+  it("logs the audit failure with structured context (code + name + message), not just err.message", () => {
+    const missingInput = join(tmpRoot, "does-not-exist.ndjson");
+    const result = runSweep([
+      "--input", missingInput,
+      "--dir", outDir,
+      "--skills-dir", emptySkillsDir,
+      "--session-log-dir", emptySessionDir,
+    ]);
+
+    const combined = result.stderr + result.stdout;
+    expect(combined).toContain("[sweep:audit]");
+    expect(combined).toContain("ENOENT");
+  });
+
+  it("still runs phase 2 after phase 1 fails (one-bad-phase invariant preserved)", () => {
+    const missingInput = join(tmpRoot, "does-not-exist.ndjson");
+    const result = runSweep([
+      "--input", missingInput,
+      "--dir", outDir,
+      "--skills-dir", emptySkillsDir,
+      "--session-log-dir", emptySessionDir,
+    ]);
+
+    // Phase 2 emits a [sweep:skill] line even when skills dir is empty
+    // ("no vendored skills found … — skipping skill-metrics phase"). That
+    // line is the evidence that phase 2 ran despite phase 1 throwing.
+    expect(result.stdout).toContain("[sweep:skill]");
+  });
+
+  it("exits 0 when both phases are skipped (no false-positive non-zero exit)", () => {
+    const result = runSweep([
+      "--skip-audit",
+      "--skip-skill-metrics",
+      "--dir", outDir,
+    ]);
+    expect(result.status).toBe(0);
+  });
+});

--- a/tests/scripts/sweep-improvements-error-handling.test.ts
+++ b/tests/scripts/sweep-improvements-error-handling.test.ts
@@ -1,20 +1,29 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-// Integration tests for the .mjs sweep script. Invoked via the same tsx
-// wrapper used by `npm run sweep-improvements` so transpilation matches prod.
 const REPO_ROOT = resolve(__dirname, "..", "..");
 const SCRIPT = "scripts/sweep-improvements.mjs";
 
 function runSweep(args: string[]): ReturnType<typeof spawnSync> {
-  return spawnSync("npx", ["tsx", SCRIPT, ...args], {
+  // Invoked via `npx tsx` so transpilation matches `npm run sweep-improvements`.
+  const result = spawnSync("npx", ["tsx", SCRIPT, ...args], {
     cwd: REPO_ROOT,
     encoding: "utf8",
     env: { ...process.env, NO_COLOR: "1" },
   });
+  // Surface OS-level launcher failures (PATH issue, sandbox restriction,
+  // tsx network pull) as a loud throw instead of `result.status === null`
+  // silently satisfying `expect(...).not.toBe(0)`.
+  if (result.error) throw result.error;
+  if (result.status === null) {
+    throw new Error(
+      `spawnSync returned null status (signal=${result.signal}); stderr was: ${result.stderr}`
+    );
+  }
+  return result;
 }
 
 let tmpRoot: string;
@@ -49,7 +58,7 @@ describe("sweep-improvements error handling (#64)", () => {
     expect(result.status).not.toBe(0);
   });
 
-  it("logs the audit failure with structured context (code + name + message), not just err.message", () => {
+  it("logs the audit failure in the structured `FAILED (<name> <code>): <message>` shape", () => {
     const missingInput = join(tmpRoot, "does-not-exist.ndjson");
     const result = runSweep([
       "--input", missingInput,
@@ -59,8 +68,10 @@ describe("sweep-improvements error handling (#64)", () => {
     ]);
 
     const combined = result.stderr + result.stdout;
-    expect(combined).toContain("[sweep:audit]");
-    expect(combined).toContain("ENOENT");
+    // FAILED keyword + (name code) parens + colon + non-empty message —
+    // pinning the full shape so a regression that drops the parens, the
+    // FAILED keyword, or the message slips no further.
+    expect(combined).toMatch(/\[sweep:audit\] FAILED \(\S+ ENOENT\): \S+/);
   });
 
   it("still runs phase 2 after phase 1 fails (one-bad-phase invariant preserved)", () => {
@@ -76,6 +87,32 @@ describe("sweep-improvements error handling (#64)", () => {
     // ("no vendored skills found … — skipping skill-metrics phase"). That
     // line is the evidence that phase 2 ran despite phase 1 throwing.
     expect(result.stdout).toContain("[sweep:skill]");
+  });
+
+  it("exits non-zero and logs the structured failure when the skill-metrics phase throws", () => {
+    // Trigger phase 2 to throw ENOTDIR: pass a populated skillsDir (so the
+    // `if (skills.length === 0) skip` short-circuit doesn't fire) and a
+    // --session-log-dir that points at a regular file rather than a dir,
+    // so `collectInvocations`'s `readdirSync` throws ENOTDIR.
+    const skillsRoot = join(tmpRoot, "skills");
+    mkdirSync(join(skillsRoot, "trial-skill"), { recursive: true });
+    writeFileSync(
+      join(skillsRoot, "trial-skill", "SKILL.md"),
+      "---\nname: trial-skill\n---\n\n## Provenance\n\nVendored.\n"
+    );
+    const sessionAsFile = join(tmpRoot, "not-a-dir.txt");
+    writeFileSync(sessionAsFile, "not a directory\n");
+
+    const result = runSweep([
+      "--skip-audit",
+      "--dir", outDir,
+      "--skills-dir", skillsRoot,
+      "--session-log-dir", sessionAsFile,
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const combined = result.stderr + result.stdout;
+    expect(combined).toMatch(/\[sweep:skill\] FAILED \(\S+ ENOTDIR\): \S+/);
   });
 
   it("exits 0 when both phases are skipped (no false-positive non-zero exit)", () => {


### PR DESCRIPTION
## Summary

- Track per-phase failure flags (`auditFailed`, `skillMetricsFailed`) and set `process.exitCode = 1` after both phases complete if either threw. Loud failure: launchd surfaces non-zero exit; the operator stops guessing why the suggestion pipeline went quiet.
- Extract `logPhaseFailure(phase, err)`: structured prefix with `err.name`, `err.code` (NodeJS.ErrnoException), `err.message`, plus stack. Mirrors the convention introduced for `readVendoredSkills` in #63.
- **Invariant preserved:** "one bad phase does not block the other." Both phase catches stay in place; only the exit code escalates after both have run.

## Test plan

- [x] `tests/scripts/sweep-improvements-error-handling.test.ts` (4 new integration tests via `spawnSync npx tsx scripts/sweep-improvements.mjs`):
  - Missing `--input` file → non-zero exit
  - Failure logs include `[sweep:audit]` + `ENOENT`
  - Phase 2 still runs after phase 1 fails (asserts `[sweep:skill]` in stdout)
  - `--skip-audit --skip-skill-metrics` baseline → exit 0
- [x] Full suite passes (749 tests, +4 from this PR)
- [x] `npm run typecheck` clean
- [x] No new dependencies

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)