### PR TITLE
feat: surface readVendoredSkills skip count in report header (#66)

### DIFF
--- a/scripts/sweep-improvements.mjs
+++ b/scripts/sweep-improvements.mjs
@@ -147,7 +147,12 @@ if (!opts.skipSkillMetrics) {
     const windowStart = new Date(now.getTime() - lookbackMs).toISOString();
     const windowEnd = now.toISOString();
 
-    const skills = readVendoredSkills(skillsDir);
+    let skippedSkillsCount = 0;
+    const skills = readVendoredSkills(skillsDir, {
+      onSkip: () => {
+        skippedSkillsCount++;
+      },
+    });
     if (skills.length === 0) {
       console.log(`[sweep:skill] no vendored skills found in ${skillsDir} — skipping skill-metrics phase`);
     } else {
@@ -160,7 +165,8 @@ if (!opts.skipSkillMetrics) {
         windowStart,
         windowEnd,
         now,
-        parseStats
+        parseStats,
+        skippedSkillsCount
       );
       const metricsDir = join(dir, "metrics");
       if (!existsSync(metricsDir)) mkdirSync(metricsDir, { recursive: true });
@@ -173,6 +179,12 @@ if (!opts.skipSkillMetrics) {
       console.log(
         `[sweep:skill] parsed ${parseStats.filesScanned} files, ${parseStats.totalLines} lines, ${parseStats.malformedLines} malformed`
       );
+      if (skippedSkillsCount > 0) {
+        // Echo the skip count to stdout so a casual sweep log scan flags it
+        // alongside the markdown header (#66). The per-skill detail is already
+        // in the [readVendoredSkills] warn lines higher in the same log.
+        console.log(`[sweep:skill] ${skippedSkillsCount} skill(s) skipped due to fs errors — see warnings above`);
+      }
 
       // Run anti-signal detector.
       const skillSuggestions = detectSkillUsageImprovements(invocations, skills, { now });

--- a/scripts/sweep-improvements.mjs
+++ b/scripts/sweep-improvements.mjs
@@ -181,9 +181,10 @@ if (!opts.skipSkillMetrics) {
       );
       if (skippedSkillsCount > 0) {
         // Echo the skip count to stdout so a casual sweep log scan flags it
-        // alongside the markdown header (#66). The per-skill detail is already
-        // in the [readVendoredSkills] warn lines higher in the same log.
-        console.log(`[sweep:skill] ${skippedSkillsCount} skill(s) skipped due to fs errors — see warnings above`);
+        // alongside the markdown header. The per-skill detail is already in
+        // the [readVendoredSkills] warn lines higher in the same log.
+        const pluralized = skippedSkillsCount === 1 ? "skill" : "skills";
+        console.log(`[sweep:skill] ${skippedSkillsCount} ${pluralized} skipped due to fs errors — see warnings above`);
       }
 
       // Run anti-signal detector.

--- a/src/improvements/skill-usage-report.ts
+++ b/src/improvements/skill-usage-report.ts
@@ -53,13 +53,11 @@ export interface SkillUsageMetrics {
   /** Optional — surfaced from collectInvocations so the report flags transcript drift. */
   readonly parseStats?: ParseStats;
   /**
-   * Count of vendored skill directories `readVendoredSkills` had to skip due
-   * to an fs error. Surfaced in the report header (next to
-   * `parseStats.malformedLines`) so the reader can't miss it — a non-zero
-   * value means `[readVendoredSkills]` warnings were emitted to the sweep
-   * log and the metrics may understate trial activity. See issue #66.
+   * Count of vendored skill directories that `readVendoredSkills` could not
+   * read. A non-zero value means `[readVendoredSkills]` warnings were
+   * emitted to the sweep log and trial activity counts may be understated.
    */
-  readonly skippedSkillsCount?: number;
+  readonly skippedSkillsCount: number;
 }
 
 interface VerdictRule {
@@ -121,8 +119,10 @@ const PROVENANCE_MARKER = "## Provenance";
 export interface ReadVendoredSkillsOptions {
   /**
    * Invoked once per directory entry that was skipped due to an fs error
-   * (in addition to the `[readVendoredSkills]` console.warn). Lets callers
-   * tally skipped skills for surfacing in the report header — see #66.
+   * (in addition to the `[readVendoredSkills]` console.warn). Callers can
+   * tally these to surface a count to operators. Exceptions thrown from
+   * this callback are caught and logged — they will not abort the scan
+   * or lose readable siblings.
    */
   readonly onSkip?: (name: string, err: unknown) => void;
 }
@@ -150,7 +150,7 @@ export function readVendoredSkills(
       isDir = statSync(skillDir).isDirectory();
     } catch (err) {
       warnSkipped(name, err);
-      options.onSkip?.(name, err);
+      notifySkip(options.onSkip, name, err);
       continue;
     }
     if (!isDir) continue;
@@ -163,7 +163,7 @@ export function readVendoredSkills(
       mtime = statSync(skillMd).mtime;
     } catch (err) {
       warnSkipped(name, err);
-      options.onSkip?.(name, err);
+      notifySkip(options.onSkip, name, err);
       continue;
     }
     if (!content.includes(PROVENANCE_MARKER)) continue;
@@ -184,6 +184,26 @@ function warnSkipped(name: string, err: unknown): void {
   );
 }
 
+function notifySkip(
+  callback: ReadVendoredSkillsOptions["onSkip"],
+  name: string,
+  err: unknown
+): void {
+  if (!callback) return;
+  // An observer callback must not break the scan loop — a buggy counter or
+  // a thrown logger here would drop readable siblings, undoing the
+  // swallow-and-continue invariant that's the whole point of warnSkipped.
+  try {
+    callback(name, err);
+  } catch (callbackErr) {
+    const code = (callbackErr as NodeJS.ErrnoException | undefined)?.code;
+    const message = callbackErr instanceof Error ? callbackErr.message : String(callbackErr);
+    console.warn(
+      `[readVendoredSkills] onSkip callback threw on ${name}: ${code ?? "UNKNOWN"} ${message}`
+    );
+  }
+}
+
 export function computeMetrics(
   invocations: readonly ClassifiedInvocation[],
   skills: readonly VendoredSkill[],
@@ -191,7 +211,7 @@ export function computeMetrics(
   windowEnd: string,
   now: Date = new Date(),
   parseStats?: ParseStats,
-  skippedSkillsCount?: number
+  skippedSkillsCount: number = 0
 ): SkillUsageMetrics {
   const trialSkillNames = new Set(skills.map((s) => s.name));
   const trialInvocationList = invocations.filter((i) => trialSkillNames.has(i.skillName));
@@ -303,7 +323,7 @@ export function renderReport(metrics: SkillUsageMetrics): string {
         : `${ps.totalLines} lines, ${ps.malformedLines} malformed ⚠️ — investigate transcript-format drift`;
     lines.push(`**Transcripts scanned:** ${ps.filesScanned} (${malformedNote})`);
   }
-  if (metrics.skippedSkillsCount !== undefined && metrics.skippedSkillsCount > 0) {
+  if (metrics.skippedSkillsCount > 0) {
     lines.push(
       `**Skipped skills:** ${metrics.skippedSkillsCount} ⚠️ — see \`[readVendoredSkills]\` diagnostics in the launchd sweep log (\`~/Library/Logs/agentic-press-skill-metrics.log\`); trial counts below may be understated.`
     );

--- a/src/improvements/skill-usage-report.ts
+++ b/src/improvements/skill-usage-report.ts
@@ -52,6 +52,14 @@ export interface SkillUsageMetrics {
   readonly perSkill: readonly PerSkillMetrics[];
   /** Optional — surfaced from collectInvocations so the report flags transcript drift. */
   readonly parseStats?: ParseStats;
+  /**
+   * Count of vendored skill directories `readVendoredSkills` had to skip due
+   * to an fs error. Surfaced in the report header (next to
+   * `parseStats.malformedLines`) so the reader can't miss it — a non-zero
+   * value means `[readVendoredSkills]` warnings were emitted to the sweep
+   * log and the metrics may understate trial activity. See issue #66.
+   */
+  readonly skippedSkillsCount?: number;
 }
 
 interface VerdictRule {
@@ -110,16 +118,29 @@ const VERDICT_RULES: Record<string, VerdictRule> = {
 
 const PROVENANCE_MARKER = "## Provenance";
 
+export interface ReadVendoredSkillsOptions {
+  /**
+   * Invoked once per directory entry that was skipped due to an fs error
+   * (in addition to the `[readVendoredSkills]` console.warn). Lets callers
+   * tally skipped skills for surfacing in the report header — see #66.
+   */
+  readonly onSkip?: (name: string, err: unknown) => void;
+}
+
 /**
  * Scan `.claude/skills/` for vendored skills — those whose SKILL.md carries
  * the provenance footer marker. Project-authored skills (without the marker)
  * are excluded so the trial's metrics stay scoped to the cherry-picked set.
  *
  * An fs error on a single skill (EACCES, EISDIR, ENOENT on a stale symlink,
- * etc.) emits a `[readVendoredSkills]` warning and skips that skill —
- * other readable skills are still returned, and the sweep continues.
+ * etc.) emits a `[readVendoredSkills]` warning, fires `options.onSkip`
+ * if provided, and skips that skill — other readable skills are still
+ * returned and the sweep continues.
  */
-export function readVendoredSkills(skillsDir: string): VendoredSkill[] {
+export function readVendoredSkills(
+  skillsDir: string,
+  options: ReadVendoredSkillsOptions = {}
+): VendoredSkill[] {
   if (!existsSync(skillsDir)) return [];
   const out: VendoredSkill[] = [];
   for (const name of readdirSync(skillsDir)) {
@@ -129,6 +150,7 @@ export function readVendoredSkills(skillsDir: string): VendoredSkill[] {
       isDir = statSync(skillDir).isDirectory();
     } catch (err) {
       warnSkipped(name, err);
+      options.onSkip?.(name, err);
       continue;
     }
     if (!isDir) continue;
@@ -141,6 +163,7 @@ export function readVendoredSkills(skillsDir: string): VendoredSkill[] {
       mtime = statSync(skillMd).mtime;
     } catch (err) {
       warnSkipped(name, err);
+      options.onSkip?.(name, err);
       continue;
     }
     if (!content.includes(PROVENANCE_MARKER)) continue;
@@ -167,7 +190,8 @@ export function computeMetrics(
   windowStart: string,
   windowEnd: string,
   now: Date = new Date(),
-  parseStats?: ParseStats
+  parseStats?: ParseStats,
+  skippedSkillsCount?: number
 ): SkillUsageMetrics {
   const trialSkillNames = new Set(skills.map((s) => s.name));
   const trialInvocationList = invocations.filter((i) => trialSkillNames.has(i.skillName));
@@ -224,6 +248,7 @@ export function computeMetrics(
     trialSessionsUsedIn,
     perSkill,
     parseStats,
+    skippedSkillsCount,
   };
 }
 
@@ -277,6 +302,11 @@ export function renderReport(metrics: SkillUsageMetrics): string {
         ? `${ps.totalLines} lines, 0 malformed`
         : `${ps.totalLines} lines, ${ps.malformedLines} malformed ⚠️ — investigate transcript-format drift`;
     lines.push(`**Transcripts scanned:** ${ps.filesScanned} (${malformedNote})`);
+  }
+  if (metrics.skippedSkillsCount !== undefined && metrics.skippedSkillsCount > 0) {
+    lines.push(
+      `**Skipped skills:** ${metrics.skippedSkillsCount} ⚠️ — see \`[readVendoredSkills]\` diagnostics in the launchd sweep log (\`~/Library/Logs/agentic-press-skill-metrics.log\`); trial counts below may be understated.`
+    );
   }
   // Distinguish trial-subset activity (counts in the per-skill table) from
   // total Skill-tool activity (includes non-trial skills like pr-review-toolkit,

--- a/tests/improvements/skill-usage-report.test.ts
+++ b/tests/improvements/skill-usage-report.test.ts
@@ -284,6 +284,35 @@ describe("renderReport", () => {
     expect(out).toMatch(/includes non-trial skills/);
   });
 
+  it("flags skipped skills in the report header when skippedSkillsCount > 0", () => {
+    const skills = [skill("brainstorming", 7)];
+    const m = computeMetrics(
+      [],
+      skills,
+      NOW.toISOString(),
+      NOW.toISOString(),
+      NOW,
+      undefined,
+      2
+    );
+    const out = renderReport(m);
+    expect(out).toMatch(/Skipped skills:.*2/);
+    expect(out).toContain("⚠️");
+    expect(out).toContain("[readVendoredSkills]");
+  });
+
+  it("omits the skipped-skills header line when count is 0 or undefined", () => {
+    const skills = [skill("brainstorming", 7)];
+    const zero = renderReport(
+      computeMetrics([], skills, NOW.toISOString(), NOW.toISOString(), NOW, undefined, 0)
+    );
+    const undef = renderReport(
+      computeMetrics([], skills, NOW.toISOString(), NOW.toISOString(), NOW)
+    );
+    expect(zero).not.toMatch(/Skipped skills:/);
+    expect(undef).not.toMatch(/Skipped skills:/);
+  });
+
   it("flags malformed transcript lines in the report header when parseStats.malformedLines > 0", () => {
     const skills = [skill("brainstorming", 7)];
     const m = computeMetrics(
@@ -376,6 +405,45 @@ describe("readVendoredSkills", () => {
     writeFileSync(join(skillsRoot, "loose-file.md"), "## Provenance\n");
     mkdirSync(join(skillsRoot, "no-skill-md-here"));
     expect(readVendoredSkills(skillsRoot)).toEqual([]);
+  });
+
+  it("invokes options.onSkip once per skipped directory entry", () => {
+    const skillsRoot = join(tmpRoot, ".claude", "skills");
+    mkdirSync(join(skillsRoot, "readable"), { recursive: true });
+    writeFileSync(
+      join(skillsRoot, "readable", "SKILL.md"),
+      "---\nname: readable\n---\n\n## Provenance\n\nVendored.\n"
+    );
+    symlinkSync(join(tmpRoot, "nope"), join(skillsRoot, "broken"));
+
+    const skipped: Array<{ name: string; code: string | undefined }> = [];
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const skills = readVendoredSkills(skillsRoot, {
+        onSkip: (name, err) => {
+          skipped.push({ name, code: (err as NodeJS.ErrnoException).code });
+        },
+      });
+      expect(skills.map((s) => s.name)).toEqual(["readable"]);
+      expect(skipped).toEqual([{ name: "broken", code: "ENOENT" }]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("still warns to console.warn when options.onSkip is provided (callback is additive, not replacing)", () => {
+    const skillsRoot = join(tmpRoot, ".claude", "skills");
+    mkdirSync(join(skillsRoot, "wedged"), { recursive: true });
+    mkdirSync(join(skillsRoot, "wedged", "SKILL.md"));
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      readVendoredSkills(skillsRoot, { onSkip: () => {} });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0]![0])).toContain("[readVendoredSkills]");
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("warns and continues when the skill directory can't be stat'd (broken symlink), returning readable siblings", () => {

--- a/tests/improvements/skill-usage-report.test.ts
+++ b/tests/improvements/skill-usage-report.test.ts
@@ -436,11 +436,50 @@ describe("readVendoredSkills", () => {
     mkdirSync(join(skillsRoot, "wedged"), { recursive: true });
     mkdirSync(join(skillsRoot, "wedged", "SKILL.md"));
 
+    const skipped: Array<{ name: string; code: string | undefined }> = [];
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
-      readVendoredSkills(skillsRoot, { onSkip: () => {} });
+      readVendoredSkills(skillsRoot, {
+        onSkip: (name, err) => {
+          skipped.push({ name, code: (err as NodeJS.ErrnoException).code });
+        },
+      });
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(String(warnSpy.mock.calls[0]![0])).toContain("[readVendoredSkills]");
+      // Pin the readFileSync-catch callback payload (parallel to the
+      // statSync-catch test above which pins ENOENT). Without this a
+      // future refactor calling `options.onSkip?.(name)` at one of the
+      // two catches — dropping the second arg — would slip through.
+      expect(skipped).toEqual([{ name: "wedged", code: "EISDIR" }]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does not abort the scan when options.onSkip throws — readable siblings still come back", () => {
+    const skillsRoot = join(tmpRoot, ".claude", "skills");
+    mkdirSync(join(skillsRoot, "readable"), { recursive: true });
+    writeFileSync(
+      join(skillsRoot, "readable", "SKILL.md"),
+      "---\nname: readable\n---\n\n## Provenance\n\nVendored.\n"
+    );
+    symlinkSync(join(tmpRoot, "nope"), join(skillsRoot, "broken"));
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const skills = readVendoredSkills(skillsRoot, {
+        onSkip: () => {
+          throw new Error("observer is buggy");
+        },
+      });
+      // Invariant under test: a throwing observer must not undo the
+      // swallow-and-continue behavior that the per-skill warn protects.
+      expect(skills.map((s) => s.name)).toEqual(["readable"]);
+      // Two warns now: the original `[readVendoredSkills] skipped …` AND
+      // the `onSkip callback threw …` line.
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      const messages = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(messages.some((m) => m.includes("onSkip callback threw"))).toBe(true);
     } finally {
       warnSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

Closes the visibility loop opened by #61/#63. A `console.warn` to a launchd log nobody reads is functionally equivalent to a swallow — this PR brings the skip count forward into the markdown report's header so the trial-decision reader (deadline 2026-05-30) can't miss it.

- **`readVendoredSkills(skillsDir, options?)`** gains `options.onSkip(name, err)`. Fires once per skipped entry, in addition to the existing console.warn. Default no-op preserves the existing array-returning signature; callers opt in.
- **`SkillUsageMetrics.skippedSkillsCount?`** propagates the count, threaded as a new optional positional arg through `computeMetrics`.
- **`renderReport`** emits `**Skipped skills:** N ⚠️ — see [readVendoredSkills] diagnostics …` next to the existing `Transcripts scanned` line when count > 0. Header line is omitted at 0/undefined to avoid noise.
- **`scripts/sweep-improvements.mjs`** tallies via the callback, passes the count to `computeMetrics`, and echoes `[sweep:skill] N skill(s) skipped due to fs errors` to stdout.

## Test plan

- [x] `tests/improvements/skill-usage-report.test.ts`:
  - `onSkip` fires once per skipped entry with the correct `(name, err.code)` tuple
  - Callback is additive — `console.warn` still emits when `onSkip` is provided
  - Header line appears when `skippedSkillsCount > 0`, contains the ⚠️ glyph and the `[readVendoredSkills]` log hint
  - Header line is omitted at `0` and `undefined`
- [x] Full suite passes (749 tests)
- [x] `npm run typecheck` clean
- [x] No new dependencies

## Trade-offs considered

- **Callback vs return-shape change.** Returning `{ skills, skippedCount }` would have been more direct but breaks the 1 production + 5 test call sites without proportionate benefit. The callback is additive and lets future consumers (e.g., a structured-error sink) plug in without another signature change.
- **Eighth positional arg on `computeMetrics`.** Long signature, but matches the established style for this module. An options object refactor is a separate concern from #66.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)