### PR TITLE
chore(hooks): remove dead PreCommit block, never fired

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,18 +16,6 @@
           }
         ]
       }
-    ],
-    "PreCommit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx vitest run --reporter=verbose 2>&1",
-            "timeout": 120000,
-            "blocking": true
-          }
-        ]
-      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- `PreCommit` is not a Claude Code hook event (verified against https://code.claude.com/docs/en/hooks.md). Claude Code silently ignores unknown event keys.
- The `npx vitest run` block under `PreCommit` in `.claude/settings.json` has never executed. The 60s → 120s timeout bump in c0f8b00 was patching dead config.
- This PR deletes the block. No behavior change — the gate wasn't running.

If we want a commit-time test gate, the correct mechanism is `PreToolUse` with a `Bash(git commit*)` matcher and `blocking: true`. That's a separate decision; out of scope for this cleanup.

## Test plan
- [ ] `git diff main...HEAD -- .claude/settings.json` shows the PreCommit block removed and nothing else.
- [ ] `/hooks` in Claude Code on this branch lists only the PostToolUse hooks (the security-edit gate and the tsc check) — confirming PreCommit wasn't ever shown.
- [ ] `npm test` still passes (sanity — the deletion can't affect tests, but worth confirming nothing else is touched).