### PR TITLE
docs: capture apd dogfood findings from Tier 1.4 verification

### DIFF
--- a/.improvements/2026-05-11-apd-operator-ux.md
+++ b/.improvements/2026-05-11-apd-operator-ux.md
@@ -1,0 +1,48 @@
+---
+date: 2026-05-11
+source: dogfood-session
+status: agent-suggested
+---
+
+# apd operator-UX gaps surfaced during Tier 1.4 dogfood
+
+Agent-generated from session 2026-05-11. Not auto-loaded into context. Triage manually.
+
+## 1. Silent success path
+
+On the happy path, `apd` prints nothing to stdout/stderr until the agent itself starts producing output. The operator has no visibility into:
+
+- "session minted: ..."
+- "control-plane register OK"
+- ".mcp.json written at <path>"
+- "sandbox <name> created"
+- "policy IDs allocated: ..."
+- "exec starting"
+- "exec finished, cleaning up"
+
+This is fine for CI but rough for interactive use, especially when a step takes 10–30s (sbx create is slow on macOS because Docker Desktop has to start). Adding pino `info` lines at each transition would be cheap and high-value.
+
+## 2. `.mcp.json` rewrite requires `--force` on every rerun
+
+Because every run mints a new sessionId, the existing `.mcp.json` content always differs from the new desired content → conflict → exit 69 → operator passes `--force`. The conflict-detection logic is correct, but rerunning the same manifest twice in a row needs `--force` always. Two possible improvements:
+
+- Auto-overwrite when the existing `.mcp.json` was *written by apd itself* (detect by structure shape — has the agentic-press mcpServer block with `host.docker.internal:<port>/mcp`).
+- Print a friendlier hint ("Existing .mcp.json was likely apd-generated for a previous session — pass --force to mint a new one") rather than just the bare conflict message.
+
+## 3. Mission Control dashboard during dispatch — visibility unclear
+
+`npm run dev` enabled Mission Control at `http://localhost:3000`. I didn't open the browser this session, so I don't know what (if anything) it shows for an `apd`-driven session in real time. Worth a follow-up to verify:
+
+- Does the session appear in MC during the brief window it's registered?
+- Does the per-session allowlist show up?
+- Does the deny event (Stage B-lite Test B) appear as a visible audit entry?
+
+If not, this is a Tier 1.5 dashboard-integration gap rather than an `apd` issue, but it's the kind of thing an operator running `apd` would expect to "just work."
+
+## 4. No way to dispatch into an existing sandbox
+
+`apd` always creates a fresh sandbox. For Claude Code workflows (per issue #76) where `/login` has to happen ahead of dispatch, there's no way to say "dispatch into sandbox 'foo' that I already prepped." Probably worth a `--use-existing-sandbox <name>` flag eventually, but only after the claude-bootstrap story is decided.
+
+## 5. agentCommand contract: cwd expectation
+
+(Already filed as #75.) Adding a `cwd: string` field to the manifest entry, validated against the workspace, would be the cleanest fix and would also serve as documentation. Mentioning here to ensure the improvement isn't dropped if #75's implementation goes another way.

--- a/.learnings/2026-05-11_apd-cwd-vs-workspace-mount.md
+++ b/.learnings/2026-05-11_apd-cwd-vs-workspace-mount.md
@@ -1,0 +1,38 @@
+---
+date: 2026-05-11
+category: architecture
+source: dogfood-session
+confidence: high
+---
+
+## What happened
+
+During Tier 1.4 (`apd`) dogfooding, the dispatch CLI wrote `.mcp.json` into the workspace path on the host (e.g., `/tmp/ap-stage-b-ws/.mcp.json`). `sbx shell` correctly bind-mounted that directory at the same path inside the sandbox. However, the `sbx exec` agent process started with `cwd = /home/agent/workspace` — a different, empty directory — not the workspace mount.
+
+The first attempt at a per-session enforcement test had the agent run `cat .mcp.json` from its default cwd; the file was nowhere, even though the host workspace contained it. Adding `cd /tmp/ap-stage-b-ws` to the agentCommand fixed it.
+
+This matters for real MCP-client agents (Claude Code, Codex, etc.): most look for `.mcp.json` in the **current working directory**, not the mounted workspace path. If `apd` dispatches them without first changing into the workspace, they will silently fail to load the proxy config and may fall through to default tool behavior (or refuse to start).
+
+## Root cause
+
+`sbx exec <name> <cmd>` does not auto-cd into the workspace mount. The exec process inherits the sandbox image's default working directory (`/home/agent/workspace`, which is a separate empty home subdirectory unrelated to the host bind-mount). The workspace is bind-mounted at the host path (matching `sbx`'s "same path as host" semantic).
+
+`apd`'s `execAgent` (`src/dispatch/sbx-runner.ts`) does not currently add a `cd <workspace>` wrapper or pass `--cwd` (sbx exec has no such flag as of this session).
+
+## Rule
+
+When `apd` dispatches an agent that expects to find `.mcp.json` (or any workspace-relative file) in its cwd, either:
+
+1. Wrap the agentCommand to `cd <workspace>` first (operator's responsibility today), or
+2. Update `apd` to inject the cwd change automatically before the agent runs (preferred — tracked as a follow-up).
+
+Until #2 lands, every manifest that points at a real MCP client must begin with `["bash", "-lc", "cd <workspace> && <real-cmd>"]` or equivalent. Document this in `docs/dispatch.md` when the help/README for `apd` is written.
+
+## Evidence
+
+- Dogfood session 2026-05-11, fs-probe agent output:
+  - `pwd` → `/home/agent/workspace`
+  - `ls /home/agent/workspace` → empty (only `.` and `..`)
+  - `ls /tmp/ap-stage-b-ws` (the host workspace path) → contains `.mcp.json`
+- `sbx create shell --help`: "The workspace path is required and will be mounted inside the sandbox at the same path as on the host."
+- Distinct from `2026-04-05_sbx-workspace-mount-scope.md` (which covers mount-point scope for the `claude` agent walking up to a git root).

--- a/.learnings/2026-05-11_apd-no-claude-bootstrap.md
+++ b/.learnings/2026-05-11_apd-no-claude-bootstrap.md
@@ -1,0 +1,47 @@
+---
+date: 2026-05-11
+category: tooling
+source: dogfood-session
+confidence: high
+---
+
+## What happened
+
+Tier 1.4 dogfood attempt: the original Stage B plan was to have `apd` dispatch a Claude Code agent at a real TapToSpeak issue. The probe inside a freshly-created `sbx shell` sandbox revealed:
+
+- `which claude` → `NO_CLAUDE` (binary not installed in default sbx shell image)
+- `~/.config/claude` does not exist (no OAuth state)
+- `ANTHROPIC_API_KEY` IS set inside the sandbox (injected by sbx, not by apd — apd's env allowlist explicitly excludes it). Without `/login`, this maps to API Usage Billing, not the Max subscription.
+
+`apd`'s create path is hard-coded to `sbx create --name <n> shell <workspace>`. There is no path for `sbx claude` (which would bring claude in pre-installed and could be `/login`'d ahead of time per `.learnings/2026-04-05_sbx-login-for-max-auth.md`). There is also no mount of host `~/.config/claude` to seed credentials.
+
+## Root cause
+
+Tier 1.4's scope was the dispatch + per-session header wiring, not agent-runtime bootstrapping. The CLI takes an agentCommand verbatim and runs it; if the binary is missing or unauthed, that's the caller's problem. But in practice this makes apd unusable for the headline use case ("dispatch a Claude Code agent at an issue") without either (a) baking claude into the workspace, (b) supporting `sbx claude` as the create-time agent type, or (c) shipping a host-side credential bridge.
+
+## Rule
+
+When designing a manifest for `apd`, do not assume `claude` (or any other agent CLI) is in the sandbox PATH. Either:
+
+1. Pre-install in the agentCommand (`npm i -g @anthropic-ai/claude-code && claude ...`) — note this triggers per-token billing because OAuth state isn't present and ANTHROPIC_API_KEY is the proxy-managed token.
+2. Wait for `apd` to support `sbx claude` create paths (follow-up issue filed).
+3. Use a different agent that needs no auth (defeats the Claude-Code dogfood purpose).
+
+For the per-session header / allowlist enforcement story, a bash-with-curl agent that reads `.mcp.json` proves the wiring without burning tokens (validated this session — see Stage B-lite in the session journal).
+
+## Evidence
+
+- Dogfood session 2026-05-11, claude-probe manifest output (`/tmp/ap-claude-probe-manifest.json` run):
+  ```
+  --- which claude ---
+  NO_CLAUDE
+  --- claude --version ---
+  bash: line 1: claude: command not found
+  --- ls ~/.config/claude ---
+  ls: cannot access '/home/agent/.config/claude': No such file or directory
+  --- env (filtered) ---
+  ANTHROPIC_API_KEY=<REDACTED>
+  ```
+- `src/dispatch/sbx-runner.ts:214` hard-codes `shell` as the sbx agent type.
+- `src/dispatch/sbx-runner.ts:10-53` `ALLOWED_ENV_KEYS` does not include `ANTHROPIC_API_KEY`, confirming the in-sandbox value is sbx-injected.
+- Related: `.learnings/2026-04-05_sbx-login-for-max-auth.md`.

--- a/.learnings/LEARNING_INDEX.md
+++ b/.learnings/LEARNING_INDEX.md
@@ -9,3 +9,5 @@ Lessons learned from previous sessions. Each entry links to a detailed learning 
 | 2026-04-05 | architecture | sbx claude agent may mount parent directory as workspace, not the specified subdirectory | [link](2026-04-05_sbx-workspace-mount-scope.md) |
 | 2026-04-06 | architecture | MCP SSE transport is deprecated — use Streamable HTTP only, never implement SSE | [link](2026-04-06_mcp-sse-deprecated.md) |
 | 2026-05-09 | process | Vendored-skill trials need pre-defined success criteria + instrumentation, not calendar prompts (Superpowers cherry-pick #55) | [link](2026-05-09_superpowers-cherrypick-criteria.md) |
+| 2026-05-11 | architecture | `sbx exec` cwd defaults to `/home/agent/workspace`, not the workspace bind-mount — apd agents must `cd` first or they won't find `.mcp.json` | [link](2026-05-11_apd-cwd-vs-workspace-mount.md) |
+| 2026-05-11 | tooling | `apd` doesn't bootstrap `claude` or auth in fresh `sbx shell` sandboxes; Stage B "dispatch Claude Code" needs follow-up work before it's realistic | [link](2026-05-11_apd-no-claude-bootstrap.md) |


### PR DESCRIPTION
## Summary
- Add 2 new entries under `.learnings/` (auto-loaded into project context) and 1 under `.improvements/` (agent-suggested, not auto-loaded), capturing what we found while dogfooding `apd` against the merged Tier 1.4 dispatch CLI.
- Stage A (dispatch lifecycle: register → exec → deregister, sandbox + policy cleanup) passed end-to-end. Stage B-lite (per-session allowlist enforcement matrix, 4/4 cases) also passed — confirming the Tier 1.4 security claim works through `apd`.
- Full Stage B (Claude Code at a real TapToSpeak issue) was blocked by infrastructure gaps now tracked as #75 and #76.

## Linked issues
- #75 — `sbx exec` cwd defaults to `/home/agent/workspace`, not the workspace mount → MCP clients miss `.mcp.json`
- #76 — `claude` binary absent + no auth in default sbx shell image → `apd` cannot dispatch Claude Code today
- #77 — `ANTHROPIC_API_KEY` is in-band in the sandbox despite `apd`'s env allowlist (threat-model documentation item)

## Test plan
- [x] Confirm `.learnings/LEARNING_INDEX.md` renders correctly with the two new rows (categories: architecture + tooling).
- [ ] Confirm `.improvements/2026-05-11-apd-operator-ux.md` does NOT get auto-loaded (it lives outside `.learnings/`).
- [ ] Spot-check that the cross-references to existing learnings (`2026-04-05_sbx-login-for-max-auth.md`, `2026-04-05_sbx-workspace-mount-scope.md`) still resolve.