### PR TITLE
fix(dispatch): wrap agent command in cd-workspace prefix (#75)

### DIFF
--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -26,10 +26,15 @@ Optional fields: `sandboxName` (override the generated `ap-<type>-<id>` name), `
 To make this work transparently, `apd` wraps every `agentCommand` in:
 
 ```bash
-bash -lc 'cd "$1" && shift && exec "$@"' -- <workspace> <agentCommand...>
+bash -c 'cd "$1" || { echo "apd cwd-wrapper: cd to ..." >&2; exit 86; }; shift; exec "$@"' \
+  -- <workspace> <agentCommand...>
 ```
 
-The workspace rides as a positional argument (consumed via `cd "$1" && shift`) so paths with spaces or quotes don't need shell-escaping. `exec "$@"` replaces the wrapper shell with the agent process, so SIGTERM/SIGINT and the agent's exit code propagate unchanged.
+(`bash -c`, not `bash -lc` — a login shell would source `/etc/profile` inside the sandbox and could mutate env or corrupt stdout. The wrapper is plumbing and must not introduce side effects.)
+
+The workspace rides as a positional argument (consumed via `cd "$1"`) so paths with spaces, quotes, `$(...)`, or backticks need no shell-escaping — `"$1"` is double-quoted parameter expansion, and bash does not re-evaluate the parameter's contents. `exec "$@"` replaces the wrapper shell with the agent process, so SIGTERM/SIGINT and the agent's exit code propagate unchanged once the agent is running.
+
+If `cd` itself fails (workspace was deleted, bind-mount broke, permission denied), the wrapper exits **86** with an `apd cwd-wrapper: ...` line on stderr. The dedicated exit code makes a wrapper failure distinguishable from a real agent exit code of `1`.
 
 **Practical consequence for manifest authors:** write `agentCommand` as if your shell is already in the workspace. Don't prefix it with `cd <workspace> && …`. Relative paths in `agentCommand` are resolved against the workspace.
 
@@ -52,19 +57,20 @@ Inside the sandbox, the agent sees `pwd` = `/tmp/ap-review-ws` and `.mcp.json` i
 
 ## Environment scoping
 
-`apd` filters the host environment before invoking `sbx exec` — only a positive allow-list (PATH, HOME, locale, proxy and TLS vars, npm/node tooling) reaches the sandbox. Notably, `MCP_CONTROL_TOKEN` and any `AP_TOKEN_*` are stripped to keep the control-plane trust boundary intact. See `src/dispatch/sbx-runner.ts` for the canonical list.
+`apd` filters the host environment before invoking `sbx exec`: only a positive allow-list (PATH, HOME, locale, proxy and TLS vars, npm/node tooling) reaches the sandbox. On top of that, two forbidden **prefixes** are stripped even if accidentally allow-listed — `MCP_CONTROL*` and `AP_TOKEN*` — to keep the control-plane trust boundary intact. So `MCP_CONTROL_TOKEN`, `MCP_CONTROL_FOO`, `AP_TOKEN_SECRET`, and any future variant are all dropped before sbx ever sees them. See `src/dispatch/sbx-runner.ts` (`ALLOWED_ENV_KEYS` and `FORBIDDEN_ENV_PREFIXES`) for the canonical lists.
 
 ## Exit codes
 
 | Code | Meaning |
 |------|---------|
 | 0    | Agent exited 0; sandbox torn down cleanly. |
-| 64   | Manifest invalid or bad CLI invocation. |
+| 64   | Manifest invalid, bad CLI flag, or invalid `MCP_PROXY_PORT`. |
 | 65   | `MCP_CONTROL_TOKEN` not set. |
 | 66   | Control-plane `register` failed. |
-| 67   | `sbx create` / `sbx policy allow` / `sbx exec` failed. |
+| 67   | `sbx create` / `sbx policy allow` / `sbx exec` failed at the apd level. |
 | 68   | Workspace path invalid (missing, not absolute, not a directory). |
 | 69   | `.mcp.json` already exists in workspace (pass `--force` to overwrite). |
 | 70   | Cleanup leak — sandbox or policy may still exist (`sbx ls`, `sbx policy ls`). |
-| 71   | Internal error. |
-| *N*  | Otherwise: the agent's own exit code, unmodified by the wrapper. |
+| 71   | Internal error (uncaught exception in `apd`; see stderr). |
+| 86   | Cwd wrapper: `cd <workspace>` failed inside the sandbox (workspace missing or unmounted). Agent never ran. |
+| *N*  | Otherwise: the agent's own exit code, unmodified by the wrapper (assumes `cd` succeeded). |

--- a/docs/dispatch.md
+++ b/docs/dispatch.md
@@ -1,0 +1,70 @@
+# Dispatch CLI (`apd`) — Manifest Contract
+
+`apd` (the **a**gentic-**p**ress **d**ispatch CLI) takes a manifest describing one agent, spins up a fresh sbx sandbox, allow-lists the proxy port, writes a per-session `.mcp.json` into the workspace, and runs the agent inside the sandbox until it exits. This page documents the contract between manifest authors and what `apd` guarantees at runtime.
+
+For the broader development workflow, see [./development.md](./development.md). For the security boundary, see [./security.md](./security.md).
+
+## Manifest shape
+
+A manifest is a JSON file with an `agents` array of exactly one entry (multi-agent dispatch is a planned extension). The required fields are:
+
+| Field          | Type             | Notes |
+|----------------|------------------|-------|
+| `agentType`    | string           | Identifier sent to the control plane on `register`; bound to the per-session allowlist. |
+| `allowedTools` | string[]         | Tool names this session may call through the MCP proxy. Anything else is denied. |
+| `agentCommand` | string[]         | The command (argv-style) executed inside the sandbox. **Starts in the workspace cwd — see below.** |
+| `workspace`    | absolute path    | Bind-mounted into the sandbox at the same path. Must exist on the host and be a directory. |
+
+Optional fields: `sandboxName` (override the generated `ap-<type>-<id>` name), `extraSbxArgs` (forwarded to `sbx create shell`).
+
+## Cwd contract (issue #75)
+
+> **`agentCommand` starts with `cwd = <workspace>`.**
+
+`sbx exec` itself has no `--cwd` flag and defaults the agent process to `/home/agent/workspace`, a *separate empty directory* unrelated to the bind-mounted host workspace. Most MCP clients (Claude Code, Codex, etc.) look for `.mcp.json` in the current working directory — without a cd into the workspace they silently fall back to default tool behaviour and never pick up the proxy config that `apd` writes.
+
+To make this work transparently, `apd` wraps every `agentCommand` in:
+
+```bash
+bash -lc 'cd "$1" && shift && exec "$@"' -- <workspace> <agentCommand...>
+```
+
+The workspace rides as a positional argument (consumed via `cd "$1" && shift`) so paths with spaces or quotes don't need shell-escaping. `exec "$@"` replaces the wrapper shell with the agent process, so SIGTERM/SIGINT and the agent's exit code propagate unchanged.
+
+**Practical consequence for manifest authors:** write `agentCommand` as if your shell is already in the workspace. Don't prefix it with `cd <workspace> && …`. Relative paths in `agentCommand` are resolved against the workspace.
+
+### Example
+
+```json
+{
+  "agents": [
+    {
+      "agentType": "reviewer",
+      "allowedTools": ["echo__read_file"],
+      "workspace": "/tmp/ap-review-ws",
+      "agentCommand": ["bash", "-c", "ls -la .mcp.json && cat .mcp.json | head -20"]
+    }
+  ]
+}
+```
+
+Inside the sandbox, the agent sees `pwd` = `/tmp/ap-review-ws` and `.mcp.json` is right there in the cwd.
+
+## Environment scoping
+
+`apd` filters the host environment before invoking `sbx exec` — only a positive allow-list (PATH, HOME, locale, proxy and TLS vars, npm/node tooling) reaches the sandbox. Notably, `MCP_CONTROL_TOKEN` and any `AP_TOKEN_*` are stripped to keep the control-plane trust boundary intact. See `src/dispatch/sbx-runner.ts` for the canonical list.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | Agent exited 0; sandbox torn down cleanly. |
+| 64   | Manifest invalid or bad CLI invocation. |
+| 65   | `MCP_CONTROL_TOKEN` not set. |
+| 66   | Control-plane `register` failed. |
+| 67   | `sbx create` / `sbx policy allow` / `sbx exec` failed. |
+| 68   | Workspace path invalid (missing, not absolute, not a directory). |
+| 69   | `.mcp.json` already exists in workspace (pass `--force` to overwrite). |
+| 70   | Cleanup leak — sandbox or policy may still exist (`sbx ls`, `sbx policy ls`). |
+| 71   | Internal error. |
+| *N*  | Otherwise: the agent's own exit code, unmodified by the wrapper. |

--- a/src/dispatch/cli.ts
+++ b/src/dispatch/cli.ts
@@ -216,6 +216,7 @@ export async function runDispatchWithDeps(argv: readonly string[], deps: Dispatc
     try {
       const result = await sbxRunner.execAgent({
         name: sandboxName,
+        workspace,
         command: entry.agentCommand,
         signal: deps.signal,
       });

--- a/src/dispatch/sbx-runner.ts
+++ b/src/dispatch/sbx-runner.ts
@@ -159,18 +159,21 @@ export interface AllowNetworkResult {
 
 export interface ExecAgentOptions {
   readonly name: string;
-  /**
-   * Workspace path the agent's cwd should be set to. `sbx exec` defaults the
-   * agent's cwd to `/home/agent/workspace`, which is a separate empty dir from
-   * the bind-mounted host workspace — so an agent that does `cat .mcp.json`
-   * from its cwd hits ENOENT. We wrap the command in a small bash script that
-   * `cd`s into this path before exec'ing the real command. See issue #75 and
-   * `.learnings/2026-05-11_apd-cwd-vs-workspace-mount.md`.
-   */
+  /** Absolute path inside the sandbox where the agent should be cwd'd before
+   *  it runs. See the wrapper comment inside `execAgent` for the why. */
   readonly workspace: string;
   readonly command: readonly string[];
   readonly signal?: AbortSignal;
 }
+
+/**
+ * Exit code the cwd wrapper emits when `cd <workspace>` fails inside the
+ * sandbox (workspace missing, bind-mount broken, permission denied). Chosen
+ * outside the 0-127 "real exit code" range used by typical agents and
+ * deliberately distinct from `EXIT_CODES.SBX_FAIL=67`. Document this in
+ * `docs/dispatch.md` whenever the apd exit table changes.
+ */
+export const WRAPPER_CD_FAILED_EXIT_CODE = 86;
 
 export interface ExecAgentResult {
   readonly exitCode: number;
@@ -254,27 +257,43 @@ export function createSbxRunner(opts: SbxRunnerOptions = {}): SbxRunner {
     async execAgent({ name, workspace, command, signal }) {
       // Wrap the agent command in a small bash script that cd's into the
       // workspace before exec'ing it. `sbx exec` has no --cwd flag and its
-      // default cwd is /home/agent/workspace, distinct from the bind-mounted
-      // host workspace path. Most MCP clients (Claude Code, Codex, etc.) look
-      // for .mcp.json in the current working directory — without this cd they
-      // silently fail to find the proxy config (issue #75).
+      // default cwd is /home/agent/workspace — a separate empty dir, NOT the
+      // bind-mounted host workspace. Most MCP clients (Claude Code, Codex,
+      // etc.) look for .mcp.json in the current working directory, so without
+      // this cd they silently miss the per-session proxy config (issue #75).
       //
-      // Why not embed `cd <workspace>` directly in the script? The workspace
-      // path is operator-controlled and may contain spaces or quotes; passing
-      // it as a positional arg (consumed via `cd "$1" && shift`) bypasses any
-      // need for shell-escaping inside the script string.
+      // Why pass the workspace as `$1` instead of interpolating it into the
+      // script string? The path is operator-controlled — paths with spaces,
+      // quotes, `$(...)`, or backticks would otherwise need careful escaping.
+      // Positional-arg semantics ($1 is consumed by cd, never re-evaluated by
+      // the shell) bypass the whole escaping question. Locked by the
+      // "workspace paths with spaces/quotes" and "command-substitution-safe"
+      // tests in `tests/dispatch/sbx-runner.test.ts`.
+      //
+      // `bash -c` (not `-lc`) is deliberate: a login shell would source
+      // /etc/profile and ~/.bash_profile inside the sandbox, which can mutate
+      // env (defeating `filterEnv`) or write to stdout (corrupting agents
+      // that parse their parent's stdout). The wrapper is plumbing; it must
+      // not introduce side effects of its own.
+      //
+      // `cd "$1" || exit 86` makes a cd failure (deleted workspace, broken
+      // bind-mount, perm denied) distinguishable from `agent exited 1`. The
+      // stderr message tells the operator which side failed. Without this,
+      // we'd fix one silent failure (issue #75) and introduce a new one at
+      // the same layer.
       //
       // `exec "$@"` replaces the wrapper shell with the agent process so
-      // signals (SIGTERM from sbx, SIGINT from operator Ctrl-C) hit the agent
-      // directly and the exit code returned by sbx is the agent's, unmodified.
+      // signals (SIGTERM from sbx, SIGINT from Ctrl-C) hit the agent directly
+      // and the exit code returned by sbx is the agent's, unmodified —
+      // EXCEPT when the cd itself fails (then it's 86, see above).
       //
-      // Chose this wrapper over adding a manifest `cwd` field because every
-      // current and foreseeable manifest wants cwd = workspace. Exposing a
-      // separate cwd would be ceremony with no real use case until we hit one.
+      // Chose this wrapper over a manifest `cwd` field because no current
+      // use case wants cwd != workspace; a separate field would be ceremony
+      // until that use case shows up. Easy to add later if it does.
       const wrappedCommand: readonly string[] = [
         "bash",
-        "-lc",
-        'cd "$1" && shift && exec "$@"',
+        "-c",
+        `cd "$1" || { echo "apd cwd-wrapper: cd to \\"$1\\" failed inside sandbox (workspace may be missing or unmounted; issue #75)" >&2; exit ${WRAPPER_CD_FAILED_EXIT_CODE}; }; shift; exec "$@"`,
         "--",
         workspace,
         ...command,

--- a/src/dispatch/sbx-runner.ts
+++ b/src/dispatch/sbx-runner.ts
@@ -159,6 +159,15 @@ export interface AllowNetworkResult {
 
 export interface ExecAgentOptions {
   readonly name: string;
+  /**
+   * Workspace path the agent's cwd should be set to. `sbx exec` defaults the
+   * agent's cwd to `/home/agent/workspace`, which is a separate empty dir from
+   * the bind-mounted host workspace — so an agent that does `cat .mcp.json`
+   * from its cwd hits ENOENT. We wrap the command in a small bash script that
+   * `cd`s into this path before exec'ing the real command. See issue #75 and
+   * `.learnings/2026-05-11_apd-cwd-vs-workspace-mount.md`.
+   */
+  readonly workspace: string;
   readonly command: readonly string[];
   readonly signal?: AbortSignal;
 }
@@ -242,8 +251,35 @@ export function createSbxRunner(opts: SbxRunnerOptions = {}): SbxRunner {
       return { policyIds: matches };
     },
 
-    async execAgent({ name, command, signal }) {
-      const args = ["exec", name, ...command];
+    async execAgent({ name, workspace, command, signal }) {
+      // Wrap the agent command in a small bash script that cd's into the
+      // workspace before exec'ing it. `sbx exec` has no --cwd flag and its
+      // default cwd is /home/agent/workspace, distinct from the bind-mounted
+      // host workspace path. Most MCP clients (Claude Code, Codex, etc.) look
+      // for .mcp.json in the current working directory — without this cd they
+      // silently fail to find the proxy config (issue #75).
+      //
+      // Why not embed `cd <workspace>` directly in the script? The workspace
+      // path is operator-controlled and may contain spaces or quotes; passing
+      // it as a positional arg (consumed via `cd "$1" && shift`) bypasses any
+      // need for shell-escaping inside the script string.
+      //
+      // `exec "$@"` replaces the wrapper shell with the agent process so
+      // signals (SIGTERM from sbx, SIGINT from operator Ctrl-C) hit the agent
+      // directly and the exit code returned by sbx is the agent's, unmodified.
+      //
+      // Chose this wrapper over adding a manifest `cwd` field because every
+      // current and foreseeable manifest wants cwd = workspace. Exposing a
+      // separate cwd would be ceremony with no real use case until we hit one.
+      const wrappedCommand: readonly string[] = [
+        "bash",
+        "-lc",
+        'cd "$1" && shift && exec "$@"',
+        "--",
+        workspace,
+        ...command,
+      ];
+      const args = ["exec", name, ...wrappedCommand];
       const { out: env, dropped } = filterEnv(hostEnv);
       emitDropDebug("execAgent", dropped);
       // Inherit stdio in production so the operator sees the agent in real

--- a/tests/dispatch/sbx-runner.test.ts
+++ b/tests/dispatch/sbx-runner.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, chmodSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  chmodSync,
+  realpathSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -129,8 +138,92 @@ describe("sbx-runner", () => {
       sbxBinary: STUB_PATH,
       hostEnv: envBase({ SBX_STUB_EXIT: "42" }),
     });
-    const { exitCode } = await runner.execAgent({ name: "ap-test", command: ["claude"] });
+    const { exitCode } = await runner.execAgent({
+      name: "ap-test",
+      workspace: "/tmp/ws",
+      command: ["claude"],
+    });
     expect(exitCode).toBe(42);
+  });
+
+  it("execAgent wraps command in `bash -lc 'cd \"$1\" && shift && exec \"$@\"' -- <workspace> <cmd...>` so the agent starts at the workspace cwd (issue #75)", async () => {
+    const runner = createSbxRunner({ sbxBinary: STUB_PATH, hostEnv: envBase() });
+    await runner.execAgent({
+      name: "ap-test",
+      workspace: "/tmp/ap-cwd-ws",
+      command: ["claude", "--allowedTools", "echo__x"],
+    });
+    const argv = readCalls()[0].argv;
+    // Shape contract: exec <name> bash -lc <script> -- <workspace> <original cmd...>
+    expect(argv[0]).toBe("exec");
+    expect(argv[1]).toBe("ap-test");
+    expect(argv[2]).toBe("bash");
+    expect(argv[3]).toBe("-lc");
+    // Script body cd's into $1, then execs the rest. Keeping the workspace out
+    // of the script string means paths with spaces/quotes never need
+    // shell-escaping — they ride positional-arg semantics.
+    expect(argv[4]).toContain('cd "$1"');
+    expect(argv[4]).toContain('shift');
+    expect(argv[4]).toContain('exec "$@"');
+    expect(argv[5]).toBe("--"); // dummy $0
+    expect(argv[6]).toBe("/tmp/ap-cwd-ws");
+    expect(argv.slice(7)).toEqual(["claude", "--allowedTools", "echo__x"]);
+  });
+
+  it("workspace paths with spaces/quotes ride positional args unmodified (no shell-escape needed)", async () => {
+    const runner = createSbxRunner({ sbxBinary: STUB_PATH, hostEnv: envBase() });
+    const tricky = "/tmp/has space and 'quote' chars";
+    await runner.execAgent({ name: "ap-test", workspace: tricky, command: ["claude"] });
+    const argv = readCalls()[0].argv;
+    // The workspace appears as a single positional arg — never embedded in the
+    // script string — so the wrapper is safe against pathological paths.
+    expect(argv[6]).toBe(tricky);
+  });
+
+  it("non-zero exit code propagates through the cd-wrapper end-to-end (real bash, not just stub-recorded)", async () => {
+    // The stubs above only record argv and exit with $SBX_STUB_EXIT — they
+    // don't actually run the bash wrapper. This stub strips off "exec <name>"
+    // and execs the remaining args, so the wrapper script runs for real.
+    const realExecStub = join(STUB_BIN_DIR, "sbx-real-exec");
+    writeFileSync(realExecStub, `#!/bin/bash\nshift 2\nexec "$@"\n`, "utf8");
+    chmodSync(realExecStub, 0o755);
+    const ws = mkdtempSync(join(tmpdir(), "ap-cwd-prop-"));
+    try {
+      const runner = createSbxRunner({ sbxBinary: realExecStub, hostEnv: envBase() });
+      const { exitCode } = await runner.execAgent({
+        name: "ap-test",
+        workspace: ws,
+        command: ["bash", "-c", "exit 42"],
+      });
+      expect(exitCode).toBe(42);
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  });
+
+  it("cd-wrapper actually changes cwd to workspace before exec (pwd inside the wrapped command sees workspace)", async () => {
+    const realExecStub = join(STUB_BIN_DIR, "sbx-real-exec-pwd");
+    writeFileSync(realExecStub, `#!/bin/bash\nshift 2\nexec "$@"\n`, "utf8");
+    chmodSync(realExecStub, 0o755);
+    const ws = mkdtempSync(join(tmpdir(), "ap-cwd-pwd-"));
+    try {
+      const runner = createSbxRunner({ sbxBinary: realExecStub, hostEnv: envBase() });
+      const outFile = join(ws, "pwd.txt");
+      const { exitCode } = await runner.execAgent({
+        name: "ap-test",
+        workspace: ws,
+        // Use `pwd -P` to get the physical path so macOS's /private symlink
+        // doesn't make this assertion brittle.
+        command: ["bash", "-c", `pwd -P > "${outFile}"`],
+      });
+      expect(exitCode).toBe(0);
+      const recorded = readFileSync(outFile, "utf8").trim();
+      // On darwin, mkdtemp returns /var/folders/... but `pwd -P` resolves the
+      // /private symlink — compare against realpath so this isn't flaky.
+      expect(recorded).toBe(realpathSync(ws));
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
   });
 
   it("forwards corporate-network env vars (HTTP_PROXY, NODE_EXTRA_CA_CERTS, NPM_CONFIG_REGISTRY, etc.)", async () => {
@@ -155,7 +248,7 @@ describe("sbx-runner", () => {
         NO_COLOR: "",
       }),
     });
-    await runner.execAgent({ name: "ap-test", command: ["claude"] });
+    await runner.execAgent({ name: "ap-test", workspace: "/tmp/ws", command: ["claude"] });
     const childEnv = readCalls()[0].env;
     expect(childEnv.HTTP_PROXY).toBe("http://proxy.corp:8080");
     expect(childEnv.https_proxy).toBe("http://proxy.corp:8080");
@@ -186,7 +279,7 @@ describe("sbx-runner", () => {
         PYTHONPATH: "/some/host/path",
       }),
     });
-    await runner.execAgent({ name: "ap-test", command: ["claude"] });
+    await runner.execAgent({ name: "ap-test", workspace: "/tmp/ws", command: ["claude"] });
     const childEnv = readCalls()[0].env;
     expect(childEnv.SSH_AUTH_SOCK).toBeUndefined();
     expect(childEnv.AWS_ACCESS_KEY_ID).toBeUndefined();
@@ -205,7 +298,7 @@ describe("sbx-runner", () => {
         MYSTERIOUS_VAR: "value",
       }),
     });
-    await runner.execAgent({ name: "ap-test", command: ["claude"] });
+    await runner.execAgent({ name: "ap-test", workspace: "/tmp/ws", command: ["claude"] });
     const debugBlob = JSON.stringify(mockLogger.debug.mock.calls);
     expect(debugBlob).toMatch(/EDITOR/);
     expect(debugBlob).toMatch(/MYSTERIOUS_VAR/);
@@ -222,7 +315,7 @@ describe("sbx-runner", () => {
         AP_TOKEN_SECRET: "also-should-never-reach-abcdef",
       }),
     });
-    await runner.execAgent({ name: "ap-test", command: ["claude"] });
+    await runner.execAgent({ name: "ap-test", workspace: "/tmp/ws", command: ["claude"] });
     const calls = readCalls();
     const childEnv = calls[0].env;
     expect(childEnv.MCP_CONTROL_TOKEN).toBeUndefined();
@@ -269,7 +362,7 @@ describe("sbx-runner", () => {
         AP_TOKEN_X: "another-should-not-leak",
       }),
     });
-    await runner.execAgent({ name: "ap-test", command: ["claude"] });
+    await runner.execAgent({ name: "ap-test", workspace: "/tmp/ws", command: ["claude"] });
     const calls = readCalls();
     const childEnv = calls[0].env;
     expect(childEnv.MCP_CONTROL_FOO).toBeUndefined();
@@ -294,6 +387,7 @@ describe("sbx-runner", () => {
     setTimeout(() => controller.abort(), 50);
     const { exitCode } = await runner.execAgent({
       name: "ap-test",
+      workspace: "/tmp/ws",
       command: ["whatever"],
       signal: controller.signal,
     });

--- a/tests/dispatch/sbx-runner.test.ts
+++ b/tests/dispatch/sbx-runner.test.ts
@@ -146,7 +146,7 @@ describe("sbx-runner", () => {
     expect(exitCode).toBe(42);
   });
 
-  it("execAgent wraps command in `bash -lc 'cd \"$1\" && shift && exec \"$@\"' -- <workspace> <cmd...>` so the agent starts at the workspace cwd (issue #75)", async () => {
+  it("execAgent wraps command in `bash -c '<cd-wrapper>' -- <workspace> <cmd...>` so the agent starts at the workspace cwd (issue #75)", async () => {
     const runner = createSbxRunner({ sbxBinary: STUB_PATH, hostEnv: envBase() });
     await runner.execAgent({
       name: "ap-test",
@@ -154,15 +154,22 @@ describe("sbx-runner", () => {
       command: ["claude", "--allowedTools", "echo__x"],
     });
     const argv = readCalls()[0].argv;
-    // Shape contract: exec <name> bash -lc <script> -- <workspace> <original cmd...>
+    // Shape contract: exec <name> bash -c <script> -- <workspace> <original cmd...>
     expect(argv[0]).toBe("exec");
     expect(argv[1]).toBe("ap-test");
     expect(argv[2]).toBe("bash");
-    expect(argv[3]).toBe("-lc");
-    // Script body cd's into $1, then execs the rest. Keeping the workspace out
-    // of the script string means paths with spaces/quotes never need
-    // shell-escaping — they ride positional-arg semantics.
+    // `-c`, NOT `-lc` — login shell would source /etc/profile and friends
+    // inside the sandbox; that can mutate env (defeating filterEnv) or write
+    // to stdout (corrupting agents that parse their parent's stdout). The
+    // wrapper is plumbing and must not introduce side effects.
+    expect(argv[3]).toBe("-c");
+    // Script body cd's into $1, exits 86 with a stderr message if cd fails
+    // (so the operator can distinguish "wrapper broke" from "agent exited 1"),
+    // then execs the rest. Workspace stays out of the script string so paths
+    // with spaces/quotes/$()/backticks need no shell-escaping.
     expect(argv[4]).toContain('cd "$1"');
+    expect(argv[4]).toContain('exit 86');
+    expect(argv[4]).toContain('apd cwd-wrapper');
     expect(argv[4]).toContain('shift');
     expect(argv[4]).toContain('exec "$@"');
     expect(argv[5]).toBe("--"); // dummy $0
@@ -224,6 +231,68 @@ describe("sbx-runner", () => {
     } finally {
       rmSync(ws, { recursive: true, force: true });
     }
+  });
+
+  it("cd failure exits 86 (NOT 1) with a stderr message so the operator can distinguish wrapper failure from agent failure", async () => {
+    const realExecStub = join(STUB_BIN_DIR, "sbx-real-exec-cdfail");
+    // Capture stderr from the inner wrapper to a file so we can assert on the
+    // operator-visible message. The capture path is passed through the
+    // `SBX_STUB_*` env prefix because that's the only namespace `filterEnv`
+    // forwards to sbx children — see `ALLOWED_ENV_PREFIXES` in sbx-runner.ts.
+    writeFileSync(
+      realExecStub,
+      `#!/bin/bash\nshift 2\nexec "$@" 2>"$SBX_STUB_CDFAIL_STDERR_FILE"\n`,
+      "utf8"
+    );
+    chmodSync(realExecStub, 0o755);
+    const captureFile = join(TMP_ROOT, `cdfail-stderr-${Date.now()}.txt`);
+    const missingWs = "/tmp/ap-this-workspace-does-not-exist-abc123";
+    const runner = createSbxRunner({
+      sbxBinary: realExecStub,
+      hostEnv: envBase({ SBX_STUB_CDFAIL_STDERR_FILE: captureFile }),
+    });
+    const { exitCode } = await runner.execAgent({
+      name: "ap-test",
+      workspace: missingWs,
+      command: ["bash", "-c", "echo SHOULD_NOT_RUN"],
+    });
+    // 86 is the dedicated wrapper-cd-failure code (NOT bash's default 1 from
+    // a failed cd, NOT 0 from a happy agent). This is what makes the failure
+    // observable instead of silently masquerading as "agent exited 1".
+    expect(exitCode).toBe(86);
+    const stderr = readFileSync(captureFile, "utf8");
+    expect(stderr).toContain("apd cwd-wrapper");
+    expect(stderr).toContain(missingWs);
+    // The "should not run" inner command must never have executed.
+    expect(stderr).not.toContain("SHOULD_NOT_RUN");
+  });
+
+  it("workspace containing $(...) / backticks is treated as a literal string (no command substitution)", async () => {
+    // The wrapper script accesses the workspace via "$1". Inside a
+    // double-quoted parameter expansion, bash does NOT re-evaluate the
+    // value's contents — so a workspace path whose name happens to contain
+    // shell metacharacters cannot trigger command substitution. Locks the
+    // central security claim of the wrapper.
+    const realExecStub = join(STUB_BIN_DIR, "sbx-real-exec-injection");
+    writeFileSync(realExecStub, `#!/bin/bash\nshift 2\nexec "$@"\n`, "utf8");
+    chmodSync(realExecStub, 0o755);
+    const markerFile = join(TMP_ROOT, `wrapper-pwn-marker-${Date.now()}`);
+    // Belt-and-braces: make sure the marker doesn't pre-exist.
+    if (existsSync(markerFile)) rmSync(markerFile);
+    // Workspace path includes a command-substitution payload that would
+    // touch the marker file if the wrapper ever re-evaluated $1. This dir
+    // doesn't exist on disk, so the cd will fail with exit 86 — that's the
+    // expected outcome; the point of the test is that the marker file
+    // doesn't exist after the run.
+    const evilWs = `/tmp/ap-cdwrap-test-$(touch ${markerFile})-end`;
+    const runner = createSbxRunner({ sbxBinary: realExecStub, hostEnv: envBase() });
+    const { exitCode } = await runner.execAgent({
+      name: "ap-test",
+      workspace: evilWs,
+      command: ["bash", "-c", "echo SHOULD_NOT_RUN"],
+    });
+    expect(exitCode).toBe(86);
+    expect(existsSync(markerFile)).toBe(false);
   });
 
   it("forwards corporate-network env vars (HTTP_PROXY, NODE_EXTRA_CA_CERTS, NPM_CONFIG_REGISTRY, etc.)", async () => {


### PR DESCRIPTION
## Summary

`sbx exec` defaults the agent's cwd to `/home/agent/workspace`, which is a *separate empty directory* unrelated to the host workspace bind-mount. Most MCP clients (Claude Code, Codex, etc.) look for `.mcp.json` in the current working directory, so without a `cd` into the workspace they silently fail to load the per-session proxy config that `apd` writes there — exactly the failure mode hit during Tier 1.4 dogfooding on 2026-05-11 (see `.learnings/2026-05-11_apd-cwd-vs-workspace-mount.md`).

`execAgent` now wraps every command in:

```bash
bash -lc 'cd "$1" && shift && exec "$@"' -- <workspace> <agentCommand...>
```

- Workspace rides as a positional arg (consumed via `cd "$1" && shift`) so paths with spaces or quotes never need shell-escaping.
- `exec "$@"` replaces the wrapper shell with the agent process — signals (SIGTERM/SIGINT) and the agent's exit code propagate unchanged.

**Decision: wrapper, not a `cwd` manifest field.** Every current and foreseeable manifest wants `cwd = workspace`. Adding a separate `cwd` field would be ceremony with no use case until we hit one. The decision is documented inline in \`src/dispatch/sbx-runner.ts:execAgent\`.

## Test plan

New tests in \`tests/dispatch/sbx-runner.test.ts\`:

- [x] argv shape: \`exec <name> bash -lc 'cd \"\$1\" && shift && exec \"\$@\"' -- <workspace> <cmd...>\`
- [x] workspace paths with spaces/quotes ride positional args unmodified
- [x] non-zero exit code propagates through the cd-wrapper end-to-end (real bash, not stub-only)
- [x] \`pwd\` inside the wrapped command equals \`realpath(workspace)\` (cd actually happens)
- [x] Existing \`execAgent\` tests updated to thread the now-required \`workspace\` field.

End-to-end verified in fresh sbx sandbox \`ap-75\`:

- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean
- [x] \`npm test\` — **869/869 pass** inside sandbox (pre-existing \`/private/var\` host-only flakes go away in linux container)
- [x] Stage B-lite repro: agent runs \`bash -lc 'pwd && ls .mcp.json'\` with NO explicit cd → reports \`/tmp/ap-cwd-verify-ws\` (not \`/home/agent/workspace\`), \`.mcp.json\` found, exit 0

## Docs

New \`docs/dispatch.md\` documents the cwd contract for manifest authors: "your \`agentCommand\` starts in the workspace directory."

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)