### PR TITLE
chore: Langfuse/OTEL dep major bump check (2026-06-22)

### DIFF
--- a/.bump-check-marker.md
+++ b/.bump-check-marker.md
@@ -1,0 +1,3 @@
+# Dep bump-check marker — 2026-06-22
+
+Automated detection run. See PR body for full analysis.


### PR DESCRIPTION
## Weekly dependency drift report — 2026-06-22

Automated detection only. **Do not merge.** No production source files were changed — this PR exists solely to surface the diff in a reviewable place.

---

## Version table

| package | pinned | latest | status |
|---------|--------|--------|--------|
| `@langfuse/tracing` | 5.3.0 | 5.5.3 | ✓ current |
| `@langfuse/client` | 5.3.0 | 5.5.3 | ✓ current |
| `@langfuse/otel` | 5.3.0 | 5.5.3 | ✓ current |
| `@opentelemetry/sdk-node` | 0.217.0 | 0.219.0 | ⚠ behind by 2 minor(s) — treated as majors for pre-1.0 |

`@opentelemetry/sdk-node` is a pre-1.0 package (`0.x.y`). Per semver convention, each minor bump in a `0.x.y` series may contain breaking changes. Pinned minor is **217**; latest is **219** — two such bumps behind.

All three Langfuse packages (tracing / client / otel) are on the same major (5) and are within the current minor range. No Langfuse action required this week.

---

## `npm test` result

**864 passed, 1 failed**

```
 FAIL  tests/stdio-bridge-response-cap.test.ts
   × stdio bridge — response size cap > maxResponseBytes=0 disables the cap entirely
     Error: spawn E2BIG
      ❯ spawnServer src/mcp-proxy/stdio-bridge.ts:217:16
      ❯ getOrSpawn src/mcp-proxy/stdio-bridge.ts:396:21
      ❯ Object.call src/mcp-proxy/stdio-bridge.ts:405:23
      ❯ tests/stdio-bridge-response-cap.test.ts:340:35
```

**`E2BIG` = OS "argument list too long"** — the test passes a zero-byte response cap that causes the spawned sub-process environment to exceed the kernel's `ARG_MAX` limit. This is an environment-level constraint in the ephemeral CI container, not a dependency regression. It should be investigated independently of this bump check (the test may need to be skipped in environments with a small ARG_MAX, or the test fixture should be trimmed).

---

## Changelogs / migration guides

- **Langfuse JS SDK**: https://github.com/langfuse/langfuse-js/releases
- **OpenTelemetry JS SDK**: https://github.com/open-telemetry/opentelemetry-js/releases

For OpenTelemetry, pay attention to the `@opentelemetry/sdk-node` CHANGELOG entries between `0.217.x` and `0.219.x` for any breaking API or configuration changes before upgrading.

---

## Upgrade guidance

The file to update for any observability dependency change is **`src/observability/langfuse.ts`** — it is the sole wrapper that exposes the `Tracer` / `ActiveTrace` contract to the rest of the codebase. Refer to **PR #49** for the reference upgrade pattern (v3 → v5) to understand how the wrapper was restructured last time.

---

_Generated by weekly drift-detection agent. Close this PR once triaged._

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHnS2ukBrUX6wE6F5HTef4)_