### PR TITLE
chore: Langfuse/OTEL dep major bump check (2026-08-17)

### DIFF
--- a/.bump-check-marker.md
+++ b/.bump-check-marker.md
@@ -1,0 +1,16 @@
+# Drift Check Marker — 2026-08-17
+
+Automated weekly dependency drift detection run.
+This file exists only to give the draft PR a diff to display.
+Do not merge this file into production — it will be removed after the human reviews and decides on upgrades.
+
+## Summary
+
+| package | pinned | latest | status |
+|---------|--------|--------|--------|
+| @langfuse/tracing | 5.3.0 | 5.10.0 | ✓ current (same major) |
+| @langfuse/client | 5.3.0 | 5.10.0 | ✓ current (same major) |
+| @langfuse/otel | 5.3.0 | 5.10.0 | ✓ current (same major) |
+| @opentelemetry/sdk-node | 0.217.0 | 0.221.0 | ⚠ behind by 4 minor(s) |
+
+`npm test`: **864 passed, 1 failed**


### PR DESCRIPTION
## Weekly Dependency Drift Detection — 2026-08-17

> **Detection only.** No source changes. A human decides when and how to upgrade.

### Version Table

| package | pinned | latest | status |
|---------|--------|--------|--------|
| `@langfuse/tracing` | `5.3.0` | `5.10.0` | ✓ current (same major: 5) |
| `@langfuse/client` | `5.3.0` | `5.10.0` | ✓ current (same major: 5) |
| `@langfuse/otel` | `5.3.0` | `5.10.0` | ✓ current (same major: 5) |
| `@opentelemetry/sdk-node` | `0.217.0` | `0.221.0` | ⚠ behind by 4 minor(s) — treated as breaking per pre-1.0 semver convention |

### npm test Result

**864 passed, 1 failed**

<details>
<summary>Failure detail</summary>

```
FAIL  tests/stdio-bridge-response-cap.test.ts
  > stdio bridge — response size cap > maxResponseBytes=0 disables the cap entirely
  Error: spawn E2BIG

   ❯ spawnServer src/mcp-proxy/stdio-bridge.ts:217:16
   ❯ getOrSpawn src/mcp-proxy/stdio-bridge.ts:396:21
   ❯ Object.call src/mcp-proxy/stdio-bridge.ts:405:23
   ❯ tests/stdio-bridge-response-cap.test.ts:340:35
```

`E2BIG` (argument list too large) — the test spawns a process with an environment inherited from the CI/cloud runner where the combined env+args size exceeds the OS limit. This failure is **environment-specific** (large inherited env in cloud runners) and predates this drift-check run. Verify on the base branch before attributing it to any dep upgrade.

</details>

### Upstream Changelogs / Migration Guides

- **Langfuse JS SDK**: https://github.com/langfuse/langfuse-js/releases  
  Migration docs: https://langfuse.com/docs (search for any v5 → v6 migration page when a major drops)
- **OpenTelemetry JS SDK**: https://github.com/open-telemetry/opentelemetry-js/releases  
  Note: `0.217 → 0.221` spans 4 minor releases; review each release's breaking-change notes before upgrading.

### What to Update

- `src/observability/langfuse.ts` is the sole wrapper. It preserves a `Tracer` / `ActiveTrace` contract — see **PR #49** for the reference upgrade pattern (v3 → v5) that shows how to safely bump through majors while keeping the public interface stable.

### Trigger Criteria Met

- [x] `@opentelemetry/sdk-node` minor bump (pre-1.0, treated as breaking): `0.217.0` → `0.221.0`
- [x] `npm test` has 1 failing test (E2BIG, likely env-related — worth confirming on base branch)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfkKXh2PxV4E4TXQtirWQm)_