### PR TITLE
chore: Langfuse/OTEL dep major bump check (2026-08-24)

### DIFF
--- a/.bump-check-marker.md
+++ b/.bump-check-marker.md
@@ -1,0 +1,4 @@
+# Dependency bump check — 2026-08-24
+
+Automated drift-detection run. No source code changes.
+See PR description for version table and test results.


### PR DESCRIPTION
## Dependency drift detection — 2026-08-24

Automated weekly run. **Detection only — no source changes.** A human decides when and how to upgrade.

---

## Version table

| package | pinned | latest | status |
|---------|--------|--------|--------|
| `@langfuse/tracing` | `^5.3.0` | `5.10.1` | ✓ current |
| `@langfuse/client` | `^5.3.0` | `5.10.1` | ✓ current |
| `@langfuse/otel` | `^5.3.0` | `5.10.1` | ✓ current |
| `@opentelemetry/sdk-node` | `^0.217.0` | `0.221.0` | ⚠ behind by 4 minor(s) ← treated as major (pre-1.0 semver) |

**`@opentelemetry/sdk-node` trigger:** package is pre-1.0 (`0.x.y`), where any minor bump is a breaking-change release per semver convention. Pinned minor is `217`; latest is `221` — a 4-minor gap.

---

## `npm test` result

**864 passed, 1 failed**

```
FAIL  tests/stdio-bridge-response-cap.test.ts
  × stdio bridge — response size cap > maxResponseBytes=0 disables the cap entirely
    → spawn E2BIG
```

`E2BIG` ("Argument list too long") is thrown by the OS `execve()` syscall when the combined size of argv + env exceeds the kernel limit (~2 MiB). This test exercises `maxResponseBytes=0` (cap disabled) by spawning a subprocess with a large env. This failure is **pre-existing** — it is reproducible in this CI environment regardless of the OTEL version and is unrelated to the dep bump. See `tests/stdio-bridge-response-cap.test.ts:340`.

---

## What to look at before upgrading

### `@opentelemetry/sdk-node` 0.217 → 0.221

Release notes and migration guides:  
https://github.com/open-telemetry/opentelemetry-js/releases

Each 0.x minor may carry breaking changes. Scan release notes for `NodeSDK` API changes, tracer/exporter interface changes, and any removed/renamed exports.

**Wrapper to update:** `src/observability/langfuse.ts` — it initialises `NodeSDK` and provides the `Tracer` / `ActiveTrace` contract consumed by the rest of the codebase. Reference upgrade pattern: PR #49 (landed v3 → v5 Langfuse upgrade and adjusted the `NodeSDK` wiring at the same time).

### Langfuse packages (`@langfuse/tracing`, `@langfuse/client`, `@langfuse/otel`)

No major bump detected (`5.3.0` → `5.10.1` is within the same major). No action required, but the changelog is at:  
https://github.com/langfuse/langfuse-js/releases  
Check for any deprecation notices in the 5.x minor releases if you're doing a combined upgrade.

---
_Generated by [Claude Code](https://claude.ai/code/session_0124acWPbhKivbiXTdXKQHsV)_